### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,
     "consortiumName": "Bahía de Cádiz",
-    "itemCount": 66
+    "itemCount": 68
   },
   "lines": [
     {
@@ -1238,6 +1238,30 @@
       "inboundPath": []
     },
     {
+      "id": "173",
+      "code": "M-562",
+      "name": "Costa Ballena-Chipiona-Jerez De La Frontera",
+      "mode": "AUTOBUS",
+      "modeId": "1",
+      "operators": [
+        "Empresa Monforte S.A.U."
+      ],
+      "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
       "id": "231",
       "code": "M-974",
       "name": "Costa Ballena-Chipiona-Sanlúcar De Barrameda (Sevilla)",
@@ -1265,6 +1289,30 @@
       "id": "172",
       "code": "M-561",
       "name": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
+      "mode": "AUTOBUS",
+      "modeId": "1",
+      "operators": [
+        "Empresa Monforte S.A.U."
+      ],
+      "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "211",
+      "code": "M-564",
+      "name": "Costa Ballena-Jerez De La Frontera (Directo)",
       "mode": "AUTOBUS",
       "modeId": "1",
       "operators": [

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,
@@ -342,7 +342,7 @@
         "Autocares Samar",
         "S.A."
       ],
-      "hasNews": true,
+      "hasNews": false,
       "concession": null,
       "notes": null,
       "modeNotes": null,
@@ -717,7 +717,7 @@
         "Autocares Samar",
         "S.A."
       ],
-      "hasNews": true,
+      "hasNews": false,
       "concession": null,
       "notes": null,
       "modeNotes": null,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,
@@ -17,28 +17,6 @@
       "operators": [
         "Empresa Carrera"
       ],
-      "hasNews": true,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "14",
-      "code": "M-140",
-      "name": "Córdoba - Cordobesas",
-      "mode": "Bus",
-      "modeId": "1",
-      "operators": [],
       "hasNews": true,
       "concession": null,
       "notes": null,
@@ -136,6 +114,30 @@
         "Autotransportes San Sebastián"
       ],
       "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "124",
+      "code": "M-140",
+      "name": "Córdoba - San Sebastián de los Ballesteros",
+      "mode": "Bus",
+      "modeId": "1",
+      "operators": [
+        "Grupo Morales &amp; Marina SL"
+      ],
+      "hasNews": false,
       "concession": null,
       "notes": null,
       "modeNotes": null,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:52.005Z",
+    "generatedAt": "2026-06-18T06:37:29.425Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:55.417Z",
+    "generatedAt": "2026-06-18T06:37:33.323Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -23,7 +23,7 @@
           "lineCode": "1320",
           "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-17T10:07:00.000Z",
+          "scheduledTime": "2026-06-18T10:07:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -32,15 +32,15 @@
           "lineCode": "1320",
           "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-17T10:37:00.000Z",
+          "scheduledTime": "2026-06-18T10:37:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -60,7 +60,7 @@
           "lineCode": "1666",
           "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-17T10:31:00.000Z",
+          "scheduledTime": "2026-06-18T10:31:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -69,7 +69,7 @@
           "lineCode": "1681",
           "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-17T10:42:00.000Z",
+          "scheduledTime": "2026-06-18T10:42:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -78,7 +78,7 @@
           "lineCode": "1020",
           "lineName": "M-102A Circular Aljarafe (sentido A)",
           "destination": "SANLUCAR LA MAYOR",
-          "scheduledTime": "2026-06-17T10:46:00.000Z",
+          "scheduledTime": "2026-06-18T10:46:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -87,15 +87,15 @@
           "lineCode": "1661",
           "lineName": "M-166 Sanlúcar la Mayor - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-17T10:48:00.000Z",
+          "scheduledTime": "2026-06-18T10:48:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -115,7 +115,7 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-17T10:02:00.000Z",
+          "scheduledTime": "2026-06-18T10:02:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -124,15 +124,15 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-17T10:32:00.000Z",
+          "scheduledTime": "2026-06-18T10:32:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -148,9 +148,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -170,7 +170,7 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-17T10:04:00.000Z",
+          "scheduledTime": "2026-06-18T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -179,7 +179,7 @@
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-06-17T10:04:00.000Z",
+          "scheduledTime": "2026-06-18T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -188,15 +188,15 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-17T10:34:00.000Z",
+          "scheduledTime": "2026-06-18T10:34:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -212,9 +212,9 @@
       "nucleus": "Penal",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -230,9 +230,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -252,7 +252,7 @@
           "lineCode": "M-967",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-17T10:05:00.000Z",
+          "scheduledTime": "2026-06-18T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -261,7 +261,7 @@
           "lineCode": "M-967",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-17T10:28:00.000Z",
+          "scheduledTime": "2026-06-18T10:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -270,15 +270,15 @@
           "lineCode": "M-963",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera",
           "destination": "Jerez",
-          "scheduledTime": "2026-06-17T10:45:00.000Z",
+          "scheduledTime": "2026-06-18T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -298,7 +298,7 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-17T10:16:00.000Z",
+          "scheduledTime": "2026-06-18T10:16:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -307,15 +307,15 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Chiclana",
-          "scheduledTime": "2026-06-17T10:44:00.000Z",
+          "scheduledTime": "2026-06-18T10:44:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -335,7 +335,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-17T10:05:00.000Z",
+          "scheduledTime": "2026-06-18T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -344,7 +344,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-17T10:10:00.000Z",
+          "scheduledTime": "2026-06-18T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -353,7 +353,7 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-17T10:21:00.000Z",
+          "scheduledTime": "2026-06-18T10:21:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -362,7 +362,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-17T10:35:00.000Z",
+          "scheduledTime": "2026-06-18T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -371,7 +371,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-17T10:40:00.000Z",
+          "scheduledTime": "2026-06-18T10:40:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -380,7 +380,7 @@
           "lineCode": "M-031",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
           "destination": "Puerto Real",
-          "scheduledTime": "2026-06-17T10:51:00.000Z",
+          "scheduledTime": "2026-06-18T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -389,15 +389,15 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-17T11:00:00.000Z",
+          "scheduledTime": "2026-06-18T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -417,7 +417,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-17T10:21:00.000Z",
+          "scheduledTime": "2026-06-18T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -426,7 +426,7 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-06-17T10:28:00.000Z",
+          "scheduledTime": "2026-06-18T10:28:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -435,7 +435,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-17T10:51:00.000Z",
+          "scheduledTime": "2026-06-18T10:51:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -444,7 +444,7 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-06-17T11:08:00.000Z",
+          "scheduledTime": "2026-06-18T11:08:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -453,7 +453,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-17T11:21:00.000Z",
+          "scheduledTime": "2026-06-18T11:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -462,7 +462,7 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-06-17T11:48:00.000Z",
+          "scheduledTime": "2026-06-18T11:48:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -471,15 +471,15 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-17T11:51:00.000Z",
+          "scheduledTime": "2026-06-18T11:51:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T12:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T12:00:00.000Z"
       }
     },
     {
@@ -499,7 +499,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Granada",
-          "scheduledTime": "2026-06-17T10:39:00.000Z",
+          "scheduledTime": "2026-06-18T10:39:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -508,7 +508,7 @@
           "lineCode": "0318",
           "lineName": "Granada - Colomera",
           "destination": "Cerro Cauro",
-          "scheduledTime": "2026-06-17T10:41:00.000Z",
+          "scheduledTime": "2026-06-18T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -517,15 +517,15 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Parque del Cubillas",
-          "scheduledTime": "2026-06-17T11:30:00.000Z",
+          "scheduledTime": "2026-06-18T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T12:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T12:00:00.000Z"
       }
     },
     {
@@ -545,7 +545,7 @@
           "lineCode": "0241",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
           "destination": "Cijuela",
-          "scheduledTime": "2026-06-17T10:26:00.000Z",
+          "scheduledTime": "2026-06-18T10:26:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -554,7 +554,7 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-17T11:27:00.000Z",
+          "scheduledTime": "2026-06-18T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -563,15 +563,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-17T11:57:00.000Z",
+          "scheduledTime": "2026-06-18T11:57:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T12:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T12:00:00.000Z"
       }
     },
     {
@@ -591,15 +591,15 @@
           "lineCode": "0340",
           "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
           "destination": "Granada",
-          "scheduledTime": "2026-06-17T11:01:00.000Z",
+          "scheduledTime": "2026-06-18T11:01:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T12:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T12:00:00.000Z"
       }
     },
     {
@@ -619,7 +619,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-17T10:01:00.000Z",
+          "scheduledTime": "2026-06-18T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -628,7 +628,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-17T10:30:00.000Z",
+          "scheduledTime": "2026-06-18T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -637,7 +637,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-17T10:35:00.000Z",
+          "scheduledTime": "2026-06-18T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -646,7 +646,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-17T11:15:00.000Z",
+          "scheduledTime": "2026-06-18T11:15:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -655,7 +655,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-17T11:15:00.000Z",
+          "scheduledTime": "2026-06-18T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -664,7 +664,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-17T11:46:00.000Z",
+          "scheduledTime": "2026-06-18T11:46:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -673,15 +673,15 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-17T11:55:00.000Z",
+          "scheduledTime": "2026-06-18T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T12:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T12:00:00.000Z"
       }
     },
     {
@@ -701,15 +701,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-17T10:11:00.000Z",
+          "scheduledTime": "2026-06-18T10:11:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T10:15:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T10:15:00.000Z"
       }
     },
     {
@@ -729,15 +729,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-17T10:08:00.000Z",
+          "scheduledTime": "2026-06-18T10:08:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T10:15:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T10:15:00.000Z"
       }
     },
     {
@@ -753,9 +753,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T10:15:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T10:15:00.000Z"
       }
     },
     {
@@ -775,15 +775,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-17T10:05:00.000Z",
+          "scheduledTime": "2026-06-18T10:05:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T10:15:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T10:15:00.000Z"
       }
     },
     {
@@ -803,15 +803,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-17T10:02:00.000Z",
+          "scheduledTime": "2026-06-18T10:02:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T10:15:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T10:15:00.000Z"
       }
     },
     {
@@ -827,9 +827,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -849,15 +849,15 @@
           "lineCode": "M-150",
           "lineName": "Algeciras-Tarifa",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-17T10:45:00.000Z",
+          "scheduledTime": "2026-06-18T10:45:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -877,7 +877,7 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-17T10:30:00.000Z",
+          "scheduledTime": "2026-06-18T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -886,15 +886,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-17T10:30:00.000Z",
+          "scheduledTime": "2026-06-18T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -914,15 +914,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-17T10:03:00.000Z",
+          "scheduledTime": "2026-06-18T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -942,7 +942,7 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-17T10:45:00.000Z",
+          "scheduledTime": "2026-06-18T10:45:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -951,15 +951,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-06-17T11:00:00.000Z",
+          "scheduledTime": "2026-06-18T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -979,7 +979,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ADRA",
-          "scheduledTime": "2026-06-17T10:36:00.000Z",
+          "scheduledTime": "2026-06-18T10:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -988,7 +988,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-06-17T10:48:00.000Z",
+          "scheduledTime": "2026-06-18T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -997,15 +997,15 @@
           "lineCode": "M-384",
           "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
           "destination": "ADRA",
-          "scheduledTime": "2026-06-17T10:51:00.000Z",
+          "scheduledTime": "2026-06-18T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -1021,9 +1021,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -1039,9 +1039,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -1057,9 +1057,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -1075,9 +1075,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T11:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T11:00:00.000Z"
       }
     },
     {
@@ -1093,9 +1093,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T12:30:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T12:30:00.000Z"
       }
     },
     {
@@ -1115,7 +1115,7 @@
           "lineCode": "M20-02",
           "lineName": "Jaén - Jamilena, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T10:13:00.000Z",
+          "scheduledTime": "2026-06-18T10:13:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1124,7 +1124,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-17T10:20:00.000Z",
+          "scheduledTime": "2026-06-18T10:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1133,7 +1133,7 @@
           "lineCode": "M20-10",
           "lineName": "Jaén - Torredelcampo, 2024",
           "destination": "Torredelcampo",
-          "scheduledTime": "2026-06-17T10:25:00.000Z",
+          "scheduledTime": "2026-06-18T10:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1142,7 +1142,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T10:28:00.000Z",
+          "scheduledTime": "2026-06-18T10:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1151,7 +1151,7 @@
           "lineCode": "M20-10",
           "lineName": "Jaén - Torredelcampo, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T10:33:00.000Z",
+          "scheduledTime": "2026-06-18T10:33:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1160,7 +1160,7 @@
           "lineCode": "M20-11",
           "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T10:38:00.000Z",
+          "scheduledTime": "2026-06-18T10:38:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1169,7 +1169,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-17T10:40:00.000Z",
+          "scheduledTime": "2026-06-18T10:40:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1178,7 +1178,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-17T11:05:00.000Z",
+          "scheduledTime": "2026-06-18T11:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1187,7 +1187,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-17T11:20:00.000Z",
+          "scheduledTime": "2026-06-18T11:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1196,7 +1196,7 @@
           "lineCode": "M20-10",
           "lineName": "Jaén - Torredelcampo, 2024",
           "destination": "Torredelcampo",
-          "scheduledTime": "2026-06-17T11:25:00.000Z",
+          "scheduledTime": "2026-06-18T11:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1205,7 +1205,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T11:28:00.000Z",
+          "scheduledTime": "2026-06-18T11:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1214,7 +1214,7 @@
           "lineCode": "M20-12",
           "lineName": "Jaén - Escañuela, 2024",
           "destination": "Escañuela",
-          "scheduledTime": "2026-06-17T11:55:00.000Z",
+          "scheduledTime": "2026-06-18T11:55:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1223,7 +1223,7 @@
           "lineCode": "M20-08",
           "lineName": "Jaén - Lopera, 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-17T12:20:00.000Z",
+          "scheduledTime": "2026-06-18T12:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1232,7 +1232,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-17T12:20:00.000Z",
+          "scheduledTime": "2026-06-18T12:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1241,7 +1241,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-17T12:25:00.000Z",
+          "scheduledTime": "2026-06-18T12:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1250,15 +1250,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T12:28:00.000Z",
+          "scheduledTime": "2026-06-18T12:28:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T12:30:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T12:30:00.000Z"
       }
     },
     {
@@ -1278,7 +1278,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T10:15:00.000Z",
+          "scheduledTime": "2026-06-18T10:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1287,7 +1287,7 @@
           "lineCode": "M20-11",
           "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T10:25:00.000Z",
+          "scheduledTime": "2026-06-18T10:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1296,7 +1296,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-17T10:33:00.000Z",
+          "scheduledTime": "2026-06-18T10:33:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1305,7 +1305,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-17T10:53:00.000Z",
+          "scheduledTime": "2026-06-18T10:53:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1314,7 +1314,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T11:15:00.000Z",
+          "scheduledTime": "2026-06-18T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1323,7 +1323,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-17T11:18:00.000Z",
+          "scheduledTime": "2026-06-18T11:18:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1332,7 +1332,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-17T11:33:00.000Z",
+          "scheduledTime": "2026-06-18T11:33:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1341,7 +1341,7 @@
           "lineCode": "M20-12",
           "lineName": "Jaén - Escañuela, 2024",
           "destination": "Escañuela",
-          "scheduledTime": "2026-06-17T12:08:00.000Z",
+          "scheduledTime": "2026-06-18T12:08:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1350,15 +1350,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T12:15:00.000Z",
+          "scheduledTime": "2026-06-18T12:15:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T12:30:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T12:30:00.000Z"
       }
     },
     {
@@ -1378,7 +1378,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T10:05:00.000Z",
+          "scheduledTime": "2026-06-18T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1387,7 +1387,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-17T10:10:00.000Z",
+          "scheduledTime": "2026-06-18T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1396,7 +1396,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-17T10:15:00.000Z",
+          "scheduledTime": "2026-06-18T10:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1405,7 +1405,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T10:45:00.000Z",
+          "scheduledTime": "2026-06-18T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1414,7 +1414,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-17T11:00:00.000Z",
+          "scheduledTime": "2026-06-18T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1423,7 +1423,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-17T11:25:00.000Z",
+          "scheduledTime": "2026-06-18T11:25:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1432,7 +1432,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T11:30:00.000Z",
+          "scheduledTime": "2026-06-18T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1441,15 +1441,15 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-17T11:55:00.000Z",
+          "scheduledTime": "2026-06-18T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T12:30:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T12:30:00.000Z"
       }
     },
     {
@@ -1469,7 +1469,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-17T10:45:00.000Z",
+          "scheduledTime": "2026-06-18T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1478,7 +1478,7 @@
           "lineCode": "M3-103",
           "lineName": "Úbeda - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-17T11:00:00.000Z",
+          "scheduledTime": "2026-06-18T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1487,7 +1487,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-17T11:25:00.000Z",
+          "scheduledTime": "2026-06-18T11:25:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1496,7 +1496,7 @@
           "lineCode": "M1-20",
           "lineName": "Pozo Alcón - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-17T12:00:00.000Z",
+          "scheduledTime": "2026-06-18T12:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1505,15 +1505,15 @@
           "lineCode": "M1-5",
           "lineName": "Quesada - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-17T12:00:00.000Z",
+          "scheduledTime": "2026-06-18T12:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T12:30:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T12:30:00.000Z"
       }
     },
     {
@@ -1529,9 +1529,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-18T02:39:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-19T02:39:00.000Z"
       }
     },
     {
@@ -1547,9 +1547,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-18T02:39:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-19T02:39:00.000Z"
       }
     },
     {
@@ -1565,9 +1565,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-18T02:39:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-19T02:39:00.000Z"
       }
     },
     {
@@ -1583,9 +1583,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-18T02:39:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-19T02:39:00.000Z"
       }
     },
     {
@@ -1601,9 +1601,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-18T02:39:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-19T02:39:00.000Z"
       }
     },
     {
@@ -1623,7 +1623,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-17T10:05:00.000Z",
+          "scheduledTime": "2026-06-18T10:05:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1632,7 +1632,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-17T10:41:00.000Z",
+          "scheduledTime": "2026-06-18T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1641,7 +1641,7 @@
           "lineCode": "M-310",
           "lineName": "Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-17T11:34:00.000Z",
+          "scheduledTime": "2026-06-18T11:34:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1650,7 +1650,7 @@
           "lineCode": "M-902",
           "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-17T11:36:00.000Z",
+          "scheduledTime": "2026-06-18T11:36:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1659,7 +1659,7 @@
           "lineCode": "M-306",
           "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-17T11:44:00.000Z",
+          "scheduledTime": "2026-06-18T11:44:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1668,7 +1668,7 @@
           "lineCode": "M-306",
           "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-17T12:06:00.000Z",
+          "scheduledTime": "2026-06-18T12:06:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1677,7 +1677,7 @@
           "lineCode": "M-316",
           "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
           "destination": "VILLABLANCA",
-          "scheduledTime": "2026-06-17T12:36:00.000Z",
+          "scheduledTime": "2026-06-18T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1686,7 +1686,7 @@
           "lineCode": "M-316",
           "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
           "destination": "VILLABLANCA",
-          "scheduledTime": "2026-06-17T12:36:00.000Z",
+          "scheduledTime": "2026-06-18T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1695,7 +1695,7 @@
           "lineCode": "M-902",
           "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-17T13:36:00.000Z",
+          "scheduledTime": "2026-06-18T13:36:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1704,7 +1704,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-17T13:41:00.000Z",
+          "scheduledTime": "2026-06-18T13:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1713,15 +1713,15 @@
           "lineCode": "M-902",
           "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-17T13:52:00.000Z",
+          "scheduledTime": "2026-06-18T13:52:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T14:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T14:00:00.000Z"
       }
     },
     {
@@ -1741,7 +1741,7 @@
           "lineCode": "M-314",
           "lineName": "Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-17T10:30:00.000Z",
+          "scheduledTime": "2026-06-18T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1750,7 +1750,7 @@
           "lineCode": "M-310",
           "lineName": "Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-17T11:14:00.000Z",
+          "scheduledTime": "2026-06-18T11:14:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1759,7 +1759,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-17T11:20:00.000Z",
+          "scheduledTime": "2026-06-18T11:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1768,7 +1768,7 @@
           "lineCode": "M-306",
           "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-17T11:20:00.000Z",
+          "scheduledTime": "2026-06-18T11:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1777,7 +1777,7 @@
           "lineCode": "M-314",
           "lineName": "Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-17T11:30:00.000Z",
+          "scheduledTime": "2026-06-18T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1786,7 +1786,7 @@
           "lineCode": "M-306",
           "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-17T12:29:00.000Z",
+          "scheduledTime": "2026-06-18T12:29:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1795,15 +1795,15 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-17T13:20:00.000Z",
+          "scheduledTime": "2026-06-18T13:20:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T14:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T14:00:00.000Z"
       }
     },
     {
@@ -1823,7 +1823,7 @@
           "lineCode": "M-906",
           "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
           "destination": "ROCIANA DEL CONDADO",
-          "scheduledTime": "2026-06-17T12:28:00.000Z",
+          "scheduledTime": "2026-06-18T12:28:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1832,7 +1832,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-06-17T12:33:00.000Z",
+          "scheduledTime": "2026-06-18T12:33:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1841,7 +1841,7 @@
           "lineCode": "M-405",
           "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-06-17T12:36:00.000Z",
+          "scheduledTime": "2026-06-18T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1850,7 +1850,7 @@
           "lineCode": "M-407",
           "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-17T13:17:00.000Z",
+          "scheduledTime": "2026-06-18T13:17:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1859,15 +1859,15 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-17T13:33:00.000Z",
+          "scheduledTime": "2026-06-18T13:33:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T14:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T14:00:00.000Z"
       }
     },
     {
@@ -1883,9 +1883,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T14:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T14:00:00.000Z"
       }
     },
     {
@@ -1901,9 +1901,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-17T06:45:55.417Z",
-        "startTime": "2026-06-17T10:00:00.000Z",
-        "endTime": "2026-06-17T14:00:00.000Z"
+        "requestedAt": "2026-06-18T06:37:33.323Z",
+        "startTime": "2026-06-18T10:00:00.000Z",
+        "endTime": "2026-06-18T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:48.940Z",
+    "generatedAt": "2026-06-18T06:37:25.868Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:48.940Z",
+    "generatedAt": "2026-06-18T06:37:25.868Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:48.940Z",
+    "generatedAt": "2026-06-18T06:37:25.868Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:48.940Z",
+    "generatedAt": "2026-06-18T06:37:25.868Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:48.940Z",
+    "generatedAt": "2026-06-18T06:37:25.868Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:48.940Z",
+    "generatedAt": "2026-06-18T06:37:25.868Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:48.940Z",
+    "generatedAt": "2026-06-18T06:37:25.868Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:48.940Z",
+    "generatedAt": "2026-06-18T06:37:25.868Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:48.940Z",
+    "generatedAt": "2026-06-18T06:37:25.868Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-17T06:45:48.940Z",
+    "generatedAt": "2026-06-18T06:37:25.868Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-06-18 06:38 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added two new transit lines to the Costa Ballena route network.
  * Refreshed transit line catalog data across all service regions.
  * Updated stop directory information and service schedules to reflect the latest operational data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->