### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,
     "consortiumName": "Bahía de Cádiz",
-    "itemCount": 63
+    "itemCount": 64
   },
   "lines": [
     {
@@ -112,6 +112,30 @@
       "modeId": "1",
       "operators": [
         "UTE VJA-089 (DAMAS)"
+      ],
+      "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "240",
+      "code": "M-037",
+      "name": "Cádiz-Campus De Puerto Real (Por CA-35)",
+      "mode": "AUTOBUS",
+      "modeId": "1",
+      "operators": [
+        "Transportes Generales Comes S.A."
       ],
       "hasNews": true,
       "concession": null,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:03.635Z",
+    "generatedAt": "2026-06-20T06:35:13.057Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:48:07.840Z",
+    "generatedAt": "2026-06-20T06:35:17.558Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -17,30 +17,11 @@
       },
       "municipality": "DOS HERMANAS",
       "nucleus": "FUENTE DEL REY (Dos Hermanas) zonaC",
-      "services": [
-        {
-          "lineId": "242",
-          "lineCode": "1320",
-          "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-19T10:07:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "242",
-          "lineCode": "1320",
-          "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-19T10:37:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -60,7 +41,7 @@
           "lineCode": "1666",
           "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-19T10:31:00.000Z",
+          "scheduledTime": "2026-06-20T10:31:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -69,33 +50,15 @@
           "lineCode": "1681",
           "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-19T10:42:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "290",
-          "lineCode": "1020",
-          "lineName": "M-102A Circular Aljarafe (sentido A)",
-          "destination": "SANLUCAR LA MAYOR",
-          "scheduledTime": "2026-06-19T10:46:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "279",
-          "lineCode": "1661",
-          "lineName": "M-166 Sanlúcar la Mayor - Sevilla",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-19T10:48:00.000Z",
+          "scheduledTime": "2026-06-20T10:57:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -115,7 +78,7 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-19T10:02:00.000Z",
+          "scheduledTime": "2026-06-20T10:17:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -124,15 +87,15 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-19T10:32:00.000Z",
+          "scheduledTime": "2026-06-20T10:47:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -148,9 +111,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -170,7 +133,7 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-19T10:04:00.000Z",
+          "scheduledTime": "2026-06-20T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -179,7 +142,7 @@
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-06-19T10:04:00.000Z",
+          "scheduledTime": "2026-06-20T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -188,15 +151,15 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-19T10:34:00.000Z",
+          "scheduledTime": "2026-06-20T10:34:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -212,9 +175,9 @@
       "nucleus": "Penal",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -230,9 +193,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -248,37 +211,46 @@
       "nucleus": "Sanlúcar de Barrameda",
       "services": [
         {
-          "lineId": "225",
-          "lineCode": "M-967",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
+          "lineId": "163",
+          "lineCode": "M-960",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-19T10:05:00.000Z",
+          "scheduledTime": "2026-06-20T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "225",
-          "lineCode": "M-967",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
+          "lineId": "230",
+          "lineCode": "M-965",
+          "lineName": "Chipiona-Sanlúcar De Barrameda (Sevilla/Utrera)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-19T10:28:00.000Z",
+          "scheduledTime": "2026-06-20T10:11:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "166",
-          "lineCode": "M-963",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera",
+          "lineId": "231",
+          "lineCode": "M-974",
+          "lineName": "Costa Ballena-Chipiona-Sanlúcar De Barrameda (Sevilla)",
+          "destination": "Costa Ballena (Rota)",
+          "scheduledTime": "2026-06-20T10:12:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "172",
+          "lineCode": "M-561",
+          "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
           "destination": "Jerez",
-          "scheduledTime": "2026-06-19T10:45:00.000Z",
+          "scheduledTime": "2026-06-20T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -292,30 +264,11 @@
       },
       "municipality": "Chiclana",
       "nucleus": "Chiclana",
-      "services": [
-        {
-          "lineId": "26",
-          "lineCode": "M-230",
-          "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
-          "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-19T10:16:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "26",
-          "lineCode": "M-230",
-          "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
-          "destination": "Chiclana",
-          "scheduledTime": "2026-06-19T10:44:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -334,17 +287,8 @@
           "lineId": "6",
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-19T10:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-19T10:10:00.000Z",
+          "scheduledTime": "2026-06-20T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -353,51 +297,15 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-19T10:21:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-19T10:35:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Cádiz",
-          "scheduledTime": "2026-06-19T10:40:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "9",
-          "lineCode": "M-031",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
-          "destination": "Puerto Real",
-          "scheduledTime": "2026-06-19T10:51:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Cádiz",
-          "scheduledTime": "2026-06-19T11:00:00.000Z",
+          "scheduledTime": "2026-06-20T10:21:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -417,69 +325,24 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-19T10:21:00.000Z",
+          "scheduledTime": "2026-06-20T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
         {
-          "lineId": "1077",
-          "lineCode": "0124",
-          "lineName": "Granada - Atarfe",
-          "destination": "Atarfe",
-          "scheduledTime": "2026-06-19T10:28:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-19T10:51:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "1077",
-          "lineCode": "0124",
-          "lineName": "Granada - Atarfe",
-          "destination": "Atarfe",
-          "scheduledTime": "2026-06-19T11:08:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-19T11:21:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "1077",
-          "lineCode": "0124",
-          "lineName": "Granada - Atarfe",
-          "destination": "Atarfe",
-          "scheduledTime": "2026-06-19T11:48:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-19T11:51:00.000Z",
+          "lineId": "992",
+          "lineCode": "0226",
+          "lineName": "Granada - P.Puente - Zujaira",
+          "destination": "Zujaira",
+          "scheduledTime": "2026-06-20T11:49:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T12:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T12:00:00.000Z"
       }
     },
     {
@@ -498,17 +361,8 @@
           "lineId": "1032",
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
-          "destination": "Granada",
-          "scheduledTime": "2026-06-19T10:39:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "710",
-          "lineCode": "0318",
-          "lineName": "Granada - Colomera",
-          "destination": "Cerro Cauro",
-          "scheduledTime": "2026-06-19T10:41:00.000Z",
+          "destination": "Centro Penitenciario de Albolote",
+          "scheduledTime": "2026-06-20T10:15:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -516,16 +370,25 @@
           "lineId": "1032",
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
-          "destination": "Parque del Cubillas",
-          "scheduledTime": "2026-06-19T11:30:00.000Z",
+          "destination": "Granada",
+          "scheduledTime": "2026-06-20T11:09:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "1032",
+          "lineCode": "0117",
+          "lineName": "Granada - P.Cubillas",
+          "destination": "Centro Penitenciario de Albolote",
+          "scheduledTime": "2026-06-20T11:45:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T12:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T12:00:00.000Z"
       }
     },
     {
@@ -541,11 +404,11 @@
       "nucleus": "Chauchina",
       "services": [
         {
-          "lineId": "868",
-          "lineCode": "0241",
-          "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
-          "destination": "Cijuela",
-          "scheduledTime": "2026-06-19T10:26:00.000Z",
+          "lineId": "1119",
+          "lineCode": "0242",
+          "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
+          "destination": "Láchar",
+          "scheduledTime": "2026-06-20T10:27:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -554,24 +417,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-19T11:27:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1119",
-          "lineCode": "0242",
-          "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
-          "destination": "Láchar",
-          "scheduledTime": "2026-06-19T11:57:00.000Z",
+          "scheduledTime": "2026-06-20T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T12:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T12:00:00.000Z"
       }
     },
     {
@@ -585,21 +439,11 @@
       },
       "municipality": "Cijuela",
       "nucleus": "Cijuela",
-      "services": [
-        {
-          "lineId": "877",
-          "lineCode": "0340",
-          "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
-          "destination": "Granada",
-          "scheduledTime": "2026-06-19T11:01:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T12:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T12:00:00.000Z"
       }
     },
     {
@@ -615,47 +459,11 @@
       "nucleus": "Ambroz",
       "services": [
         {
-          "lineId": "1113",
-          "lineCode": "0150",
-          "lineName": "Granada - Cúllar V. - V. del Genil",
-          "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-19T10:01:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
           "lineId": "1042",
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-19T10:30:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "1042",
-          "lineCode": "0154",
-          "lineName": "Granada-V. del Genil (Directo)",
-          "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-19T10:35:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1042",
-          "lineCode": "0154",
-          "lineName": "Granada-V. del Genil (Directo)",
-          "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-19T11:15:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1042",
-          "lineCode": "0154",
-          "lineName": "Granada-V. del Genil (Directo)",
-          "destination": "Granada",
-          "scheduledTime": "2026-06-19T11:15:00.000Z",
+          "scheduledTime": "2026-06-20T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -664,7 +472,16 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-19T11:46:00.000Z",
+          "scheduledTime": "2026-06-20T10:01:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "1042",
+          "lineCode": "0154",
+          "lineName": "Granada-V. del Genil (Directo)",
+          "destination": "El Ventorrillo",
+          "scheduledTime": "2026-06-20T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -673,15 +490,24 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-19T11:55:00.000Z",
+          "scheduledTime": "2026-06-20T11:15:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "1113",
+          "lineCode": "0150",
+          "lineName": "Granada - Cúllar V. - V. del Genil",
+          "destination": "El Ventorrillo",
+          "scheduledTime": "2026-06-20T11:31:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T12:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T12:00:00.000Z"
       }
     },
     {
@@ -695,21 +521,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-06-19T10:11:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T10:15:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T10:15:00.000Z"
       }
     },
     {
@@ -723,21 +539,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-06-19T10:08:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T10:15:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T10:15:00.000Z"
       }
     },
     {
@@ -753,9 +559,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T10:15:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T10:15:00.000Z"
       }
     },
     {
@@ -769,21 +575,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-06-19T10:05:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T10:15:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T10:15:00.000Z"
       }
     },
     {
@@ -797,21 +593,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-06-19T10:02:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T10:15:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T10:15:00.000Z"
       }
     },
     {
@@ -827,9 +613,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -843,21 +629,11 @@
       },
       "municipality": "Tarifa ",
       "nucleus": "Tarifa",
-      "services": [
-        {
-          "lineId": "7",
-          "lineCode": "M-150",
-          "lineName": "Algeciras-Tarifa",
-          "destination": "Algeciras",
-          "scheduledTime": "2026-06-19T10:45:00.000Z",
-          "direction": 2,
-          "stopType": 1
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -877,7 +653,7 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-19T10:30:00.000Z",
+          "scheduledTime": "2026-06-20T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -886,15 +662,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-19T10:30:00.000Z",
+          "scheduledTime": "2026-06-20T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -914,15 +690,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-19T10:03:00.000Z",
+          "scheduledTime": "2026-06-20T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -942,8 +718,17 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-19T10:45:00.000Z",
+          "scheduledTime": "2026-06-20T10:45:00.000Z",
           "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "11",
+          "lineCode": "M-230",
+          "lineName": "La Línea-San Roque",
+          "destination": "La Línea de la Concepción",
+          "scheduledTime": "2026-06-20T10:45:00.000Z",
+          "direction": 2,
           "stopType": 1
         },
         {
@@ -951,15 +736,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-06-19T11:00:00.000Z",
+          "scheduledTime": "2026-06-20T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -978,34 +763,16 @@
           "lineId": "40",
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
-          "destination": "ADRA",
-          "scheduledTime": "2026-06-19T10:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "40",
-          "lineCode": "M-380",
-          "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-06-19T10:48:00.000Z",
+          "scheduledTime": "2026-06-20T10:33:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "48",
-          "lineCode": "M-384",
-          "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
-          "destination": "ADRA",
-          "scheduledTime": "2026-06-19T10:51:00.000Z",
-          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -1021,9 +788,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -1039,9 +806,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -1057,9 +824,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -1075,9 +842,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T11:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T11:00:00.000Z"
       }
     },
     {
@@ -1093,9 +860,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T12:30:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T12:30:00.000Z"
       }
     },
     {
@@ -1111,11 +878,11 @@
       "nucleus": "Torredelcampo",
       "services": [
         {
-          "lineId": "279",
-          "lineCode": "M20-02",
-          "lineName": "Jaén - Jamilena, 2024",
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-19T10:13:00.000Z",
+          "scheduledTime": "2026-06-20T10:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1124,43 +891,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-19T10:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "286",
-          "lineCode": "M20-10",
-          "lineName": "Jaén - Torredelcampo, 2024",
-          "destination": "Torredelcampo",
-          "scheduledTime": "2026-06-19T10:25:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-19T10:28:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "286",
-          "lineCode": "M20-10",
-          "lineName": "Jaén - Torredelcampo, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-19T10:33:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-19T10:38:00.000Z",
+          "scheduledTime": "2026-06-20T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1169,70 +900,25 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-19T10:40:00.000Z",
+          "scheduledTime": "2026-06-20T11:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-19T11:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-19T11:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "286",
-          "lineCode": "M20-10",
-          "lineName": "Jaén - Torredelcampo, 2024",
-          "destination": "Torredelcampo",
-          "scheduledTime": "2026-06-19T11:25:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-19T11:28:00.000Z",
+          "lineId": "287",
+          "lineCode": "M20-11",
+          "lineName": "Fuensanta de Martos - Jaén, 2024",
+          "destination": "Fuensanta de Martos",
+          "scheduledTime": "2026-06-20T11:25:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "288",
-          "lineCode": "M20-12",
-          "lineName": "Jaén - Escañuela, 2024",
-          "destination": "Escañuela",
-          "scheduledTime": "2026-06-19T11:55:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "285",
-          "lineCode": "M20-08",
-          "lineName": "Jaén - Lopera, 2024",
-          "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-19T12:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-19T12:20:00.000Z",
+          "lineId": "279",
+          "lineCode": "M20-02",
+          "lineName": "Jaén - Jamilena, 2024",
+          "destination": "Jamilena",
+          "scheduledTime": "2026-06-20T11:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1241,7 +927,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-19T12:25:00.000Z",
+          "scheduledTime": "2026-06-20T11:55:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1250,15 +936,24 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-19T12:28:00.000Z",
+          "scheduledTime": "2026-06-20T12:08:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "280",
+          "lineCode": "M20-03",
+          "lineName": "Jaén - Villardompardo, 2024",
+          "destination": "Villardompardo",
+          "scheduledTime": "2026-06-20T12:25:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T12:30:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T12:30:00.000Z"
       }
     },
     {
@@ -1278,17 +973,8 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-19T10:15:00.000Z",
+          "scheduledTime": "2026-06-20T10:15:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-19T10:25:00.000Z",
-          "direction": 1,
           "stopType": 0
         },
         {
@@ -1296,7 +982,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-19T10:33:00.000Z",
+          "scheduledTime": "2026-06-20T10:48:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1305,16 +991,16 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-19T10:53:00.000Z",
+          "scheduledTime": "2026-06-20T11:13:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-19T11:15:00.000Z",
+          "lineId": "287",
+          "lineCode": "M20-11",
+          "lineName": "Fuensanta de Martos - Jaén, 2024",
+          "destination": "Fuensanta de Martos",
+          "scheduledTime": "2026-06-20T11:38:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1322,43 +1008,25 @@
           "lineId": "278",
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-19T11:18:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-19T11:33:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "288",
-          "lineCode": "M20-12",
-          "lineName": "Jaén - Escañuela, 2024",
-          "destination": "Escañuela",
-          "scheduledTime": "2026-06-19T12:08:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-19T12:15:00.000Z",
+          "scheduledTime": "2026-06-20T11:55:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "281",
+          "lineCode": "M20-04",
+          "lineName": "Jaén - Alcaudete, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-06-20T12:08:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T12:30:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T12:30:00.000Z"
       }
     },
     {
@@ -1374,82 +1042,37 @@
       "nucleus": "Mengíbar",
       "services": [
         {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-19T10:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-06-19T10:10:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-06-19T10:15:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
           "lineId": "203",
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-19T10:45:00.000Z",
+          "scheduledTime": "2026-06-20T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-06-19T11:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-06-19T11:25:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-19T11:30:00.000Z",
+          "lineId": "276",
+          "lineCode": "M15-7",
+          "lineName": "Jaén - Andújar - Marmolejo",
+          "destination": "Andújar",
+          "scheduledTime": "2026-06-20T10:55:00.000Z",
           "direction": 1,
-          "stopType": 0
+          "stopType": 1
         },
         {
           "lineId": "203",
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-19T11:55:00.000Z",
+          "scheduledTime": "2026-06-20T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T12:30:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T12:30:00.000Z"
       }
     },
     {
@@ -1468,35 +1091,8 @@
           "lineId": "17",
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-19T10:45:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "35",
-          "lineCode": "M3-103",
-          "lineName": "Úbeda - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-19T11:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-06-19T11:25:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "21",
-          "lineCode": "M1-20",
-          "lineName": "Pozo Alcón - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-06-19T12:00:00.000Z",
+          "scheduledTime": "2026-06-20T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1505,15 +1101,24 @@
           "lineCode": "M1-5",
           "lineName": "Quesada - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-19T12:00:00.000Z",
+          "scheduledTime": "2026-06-20T12:00:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "22",
+          "lineCode": "M1-21",
+          "lineName": "Torres - Jaén",
+          "destination": "Torres",
+          "scheduledTime": "2026-06-20T12:25:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T12:30:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T12:30:00.000Z"
       }
     },
     {
@@ -1529,9 +1134,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-20T02:39:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-21T02:39:00.000Z"
       }
     },
     {
@@ -1547,9 +1152,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-20T02:39:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-21T02:39:00.000Z"
       }
     },
     {
@@ -1565,9 +1170,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-20T02:39:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-21T02:39:00.000Z"
       }
     },
     {
@@ -1583,9 +1188,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-20T02:39:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-21T02:39:00.000Z"
       }
     },
     {
@@ -1601,9 +1206,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-20T02:39:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-21T02:39:00.000Z"
       }
     },
     {
@@ -1619,109 +1224,46 @@
       "nucleus": "LEPE",
       "services": [
         {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-19T10:05:00.000Z",
+          "scheduledTime": "2026-06-20T10:03:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-19T10:41:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "5",
-          "lineCode": "M-310",
-          "lineName": "Huelva-Isla Cristina-Ayamonte",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-19T11:34:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "66",
-          "lineCode": "M-902",
-          "lineName": "Ayamonte-Huelva-Sevilla",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-19T11:36:00.000Z",
-          "direction": 2,
+          "scheduledTime": "2026-06-20T11:22:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "3",
-          "lineCode": "M-306",
-          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-19T11:44:00.000Z",
+          "scheduledTime": "2026-06-20T12:03:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "3",
-          "lineCode": "M-306",
-          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-19T12:06:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "8",
-          "lineCode": "M-316",
-          "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
-          "destination": "VILLABLANCA",
-          "scheduledTime": "2026-06-19T12:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "8",
-          "lineCode": "M-316",
-          "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
-          "destination": "VILLABLANCA",
-          "scheduledTime": "2026-06-19T12:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "66",
-          "lineCode": "M-902",
-          "lineName": "Ayamonte-Huelva-Sevilla",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-19T13:36:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-19T13:41:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "66",
-          "lineCode": "M-902",
-          "lineName": "Ayamonte-Huelva-Sevilla",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-19T13:52:00.000Z",
+          "scheduledTime": "2026-06-20T13:22:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T14:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T14:00:00.000Z"
       }
     },
     {
@@ -1737,73 +1279,55 @@
       "nucleus": "ISLA CRISTINA",
       "services": [
         {
-          "lineId": "7",
-          "lineCode": "M-314",
-          "lineName": "Isla Cristina-Ayamonte",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-19T10:30:00.000Z",
+          "scheduledTime": "2026-06-20T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "5",
-          "lineCode": "M-310",
-          "lineName": "Huelva-Isla Cristina-Ayamonte",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-19T11:14:00.000Z",
+          "scheduledTime": "2026-06-20T11:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-19T11:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "3",
-          "lineCode": "M-306",
-          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-19T11:20:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "7",
-          "lineCode": "M-314",
-          "lineName": "Isla Cristina-Ayamonte",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-19T11:30:00.000Z",
+          "scheduledTime": "2026-06-20T12:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "3",
-          "lineCode": "M-306",
-          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-19T12:29:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-19T13:20:00.000Z",
+          "scheduledTime": "2026-06-20T13:20:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "destination": "AYAMONTE",
+          "scheduledTime": "2026-06-20T14:00:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T14:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T14:00:00.000Z"
       }
     },
     {
@@ -1819,11 +1343,38 @@
       "nucleus": "ALMONTE",
       "services": [
         {
-          "lineId": "70",
-          "lineCode": "M-906",
-          "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
-          "destination": "ROCIANA DEL CONDADO",
-          "scheduledTime": "2026-06-19T12:28:00.000Z",
+          "lineId": "75",
+          "lineCode": "M-911",
+          "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-06-20T10:14:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-06-20T10:18:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-06-20T11:03:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "50",
+          "lineCode": "M-407",
+          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
+          "destination": "BOLLULLOS PAR DEL CONDADO",
+          "scheduledTime": "2026-06-20T12:47:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1832,25 +1383,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-06-19T12:33:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "48",
-          "lineCode": "M-405",
-          "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
-          "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-06-19T12:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "50",
-          "lineCode": "M-407",
-          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-19T13:17:00.000Z",
+          "scheduledTime": "2026-06-20T12:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1859,15 +1392,24 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-19T13:33:00.000Z",
+          "scheduledTime": "2026-06-20T13:33:00.000Z",
           "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "50",
+          "lineCode": "M-407",
+          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-06-20T13:47:00.000Z",
+          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T14:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T14:00:00.000Z"
       }
     },
     {
@@ -1883,9 +1425,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T14:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T14:00:00.000Z"
       }
     },
     {
@@ -1901,9 +1443,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-19T06:48:07.840Z",
-        "startTime": "2026-06-19T10:00:00.000Z",
-        "endTime": "2026-06-19T14:00:00.000Z"
+        "requestedAt": "2026-06-20T06:35:17.558Z",
+        "startTime": "2026-06-20T10:00:00.000Z",
+        "endTime": "2026-06-20T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:47:59.488Z",
+    "generatedAt": "2026-06-20T06:35:08.640Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:47:59.488Z",
+    "generatedAt": "2026-06-20T06:35:08.640Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:47:59.488Z",
+    "generatedAt": "2026-06-20T06:35:08.640Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:47:59.488Z",
+    "generatedAt": "2026-06-20T06:35:08.640Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:47:59.488Z",
+    "generatedAt": "2026-06-20T06:35:08.640Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:47:59.488Z",
+    "generatedAt": "2026-06-20T06:35:08.640Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:47:59.488Z",
+    "generatedAt": "2026-06-20T06:35:08.640Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:47:59.488Z",
+    "generatedAt": "2026-06-20T06:35:08.640Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:47:59.488Z",
+    "generatedAt": "2026-06-20T06:35:08.640Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-19T06:47:59.488Z",
+    "generatedAt": "2026-06-20T06:35:08.640Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-06-20 06:35 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new transport route: Cádiz-Campus De Puerto Real (Por CA-35)

* **Chores**
  * Updated transport catalog metadata across all consortiums
  * Refreshed real-time service schedules and stop directory information
  * Updated metadata timestamps for catalog consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->