### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,61 +1,13 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,
     "consortiumName": "Campo de Gibraltar",
-    "itemCount": 13
+    "itemCount": 5
   },
   "lines": [
-    {
-      "id": "4",
-      "code": "M-120",
-      "name": "Algeciras-La Línea",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Transportes Generales Comes"
-      ],
-      "hasNews": true,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "7",
-      "code": "M-150",
-      "name": "Algeciras-Tarifa",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Transportes Generales Comes"
-      ],
-      "hasNews": true,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
     {
       "id": "12",
       "code": "M-240",
@@ -90,54 +42,6 @@
       "operators": [
         "AVANZA Movilidad Urbana",
         "S.L.",
-        "Transportes Generales Comes"
-      ],
-      "hasNews": true,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "27",
-      "code": "M-260",
-      "name": "La Línea-Tahivilla",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Transportes Generales Comes"
-      ],
-      "hasNews": true,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "14",
-      "code": "M-271",
-      "name": "La Línea-Tesorillo",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
         "Transportes Generales Comes"
       ],
       "hasNews": true,
@@ -206,78 +110,6 @@
       "inboundPath": []
     },
     {
-      "id": "5",
-      "code": "M-121",
-      "name": "Los Barrios-La Línea",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Transportes Generales Comes"
-      ],
-      "hasNews": true,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "10",
-      "code": "M-170",
-      "name": "San Pablo-Jimena-Castellar-Algeciras",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Transportes Generales Comes"
-      ],
-      "hasNews": true,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "28",
-      "code": "M-272",
-      "name": "San Pablo-Jimena-Castellar-Hospital-La Línea",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Transportes Generales Comes"
-      ],
-      "hasNews": true,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "6",
       "code": "M-130",
       "name": "San Roque-Algeciras",
@@ -286,30 +118,6 @@
       "operators": [
         "Empresa Esteban",
         "S.A."
-      ],
-      "hasNews": true,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "8",
-      "code": "M-160",
-      "name": "Tahivilla-Facinas-Tarifa-Algeciras",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Transportes Generales Comes"
       ],
       "hasNews": true,
       "concession": null,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:13.057Z",
+    "generatedAt": "2026-06-21T06:37:25.360Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:17.558Z",
+    "generatedAt": "2026-06-21T06:37:29.283Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -19,9 +19,9 @@
       "nucleus": "FUENTE DEL REY (Dos Hermanas) zonaC",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -37,28 +37,19 @@
       "nucleus": "ESPARTINAS",
       "services": [
         {
-          "lineId": "284",
-          "lineCode": "1666",
-          "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-20T10:31:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
           "lineId": "295",
           "lineCode": "1681",
           "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-20T10:57:00.000Z",
+          "scheduledTime": "2026-06-21T10:27:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -78,24 +69,15 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-20T10:17:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "1720",
-          "lineName": "M-170A Santiponce - Sevilla",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-20T10:47:00.000Z",
+          "scheduledTime": "2026-06-21T10:02:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -111,9 +93,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -133,7 +115,7 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-20T10:04:00.000Z",
+          "scheduledTime": "2026-06-21T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -142,24 +124,15 @@
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-06-20T10:04:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "232",
-          "lineCode": "1100",
-          "lineName": "M-110 La Algaba - Sevilla",
-          "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-20T10:34:00.000Z",
+          "scheduledTime": "2026-06-21T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -175,9 +148,9 @@
       "nucleus": "Penal",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -193,9 +166,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -215,7 +188,7 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-20T10:05:00.000Z",
+          "scheduledTime": "2026-06-21T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -224,7 +197,7 @@
           "lineCode": "M-965",
           "lineName": "Chipiona-Sanlúcar De Barrameda (Sevilla/Utrera)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-20T10:11:00.000Z",
+          "scheduledTime": "2026-06-21T10:11:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -233,7 +206,7 @@
           "lineCode": "M-974",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar De Barrameda (Sevilla)",
           "destination": "Costa Ballena (Rota)",
-          "scheduledTime": "2026-06-20T10:12:00.000Z",
+          "scheduledTime": "2026-06-21T10:12:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -242,15 +215,15 @@
           "lineCode": "M-561",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
           "destination": "Jerez",
-          "scheduledTime": "2026-06-20T10:45:00.000Z",
+          "scheduledTime": "2026-06-21T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -266,9 +239,9 @@
       "nucleus": "Chiclana",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -288,7 +261,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-20T10:10:00.000Z",
+          "scheduledTime": "2026-06-21T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -297,15 +270,33 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-20T10:21:00.000Z",
+          "scheduledTime": "2026-06-21T10:21:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "9",
+          "lineCode": "M-031",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
+          "destination": "Puerto Real",
+          "scheduledTime": "2026-06-21T10:31:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "9",
+          "lineCode": "M-031",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
+          "destination": "Cádiz",
+          "scheduledTime": "2026-06-21T10:52:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -325,7 +316,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-20T10:21:00.000Z",
+          "scheduledTime": "2026-06-21T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -334,15 +325,15 @@
           "lineCode": "0226",
           "lineName": "Granada - P.Puente - Zujaira",
           "destination": "Zujaira",
-          "scheduledTime": "2026-06-20T11:49:00.000Z",
+          "scheduledTime": "2026-06-21T11:49:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T12:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T12:00:00.000Z"
       }
     },
     {
@@ -362,7 +353,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Centro Penitenciario de Albolote",
-          "scheduledTime": "2026-06-20T10:15:00.000Z",
+          "scheduledTime": "2026-06-21T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -371,7 +362,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Granada",
-          "scheduledTime": "2026-06-20T11:09:00.000Z",
+          "scheduledTime": "2026-06-21T10:54:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -380,15 +371,15 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Centro Penitenciario de Albolote",
-          "scheduledTime": "2026-06-20T11:45:00.000Z",
+          "scheduledTime": "2026-06-21T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T12:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T12:00:00.000Z"
       }
     },
     {
@@ -408,24 +399,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-20T10:27:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1119",
-          "lineCode": "0242",
-          "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
-          "destination": "Láchar",
-          "scheduledTime": "2026-06-20T11:27:00.000Z",
+          "scheduledTime": "2026-06-21T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T12:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T12:00:00.000Z"
       }
     },
     {
@@ -441,9 +423,9 @@
       "nucleus": "Cijuela",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T12:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T12:00:00.000Z"
       }
     },
     {
@@ -463,7 +445,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-20T10:00:00.000Z",
+          "scheduledTime": "2026-06-21T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -472,7 +454,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-20T10:01:00.000Z",
+          "scheduledTime": "2026-06-21T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -481,7 +463,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-20T10:45:00.000Z",
+          "scheduledTime": "2026-06-21T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -490,7 +472,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-20T11:15:00.000Z",
+          "scheduledTime": "2026-06-21T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -499,15 +481,15 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-20T11:31:00.000Z",
+          "scheduledTime": "2026-06-21T11:31:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T12:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T12:00:00.000Z"
       }
     },
     {
@@ -523,9 +505,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T10:15:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T10:15:00.000Z"
       }
     },
     {
@@ -541,9 +523,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T10:15:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T10:15:00.000Z"
       }
     },
     {
@@ -559,9 +541,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T10:15:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T10:15:00.000Z"
       }
     },
     {
@@ -577,9 +559,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T10:15:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T10:15:00.000Z"
       }
     },
     {
@@ -595,9 +577,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T10:15:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T10:15:00.000Z"
       }
     },
     {
@@ -613,9 +595,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -631,9 +613,9 @@
       "nucleus": "Tarifa",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -652,25 +634,25 @@
           "lineId": "1",
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
-          "destination": "Los Barrios",
-          "scheduledTime": "2026-06-20T10:30:00.000Z",
-          "direction": 2,
+          "destination": "Algeciras",
+          "scheduledTime": "2026-06-21T10:30:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
           "lineId": "1",
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
-          "destination": "Algeciras",
-          "scheduledTime": "2026-06-20T10:30:00.000Z",
-          "direction": 1,
+          "destination": "Los Barrios",
+          "scheduledTime": "2026-06-21T10:30:00.000Z",
+          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -690,15 +672,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-20T10:03:00.000Z",
+          "scheduledTime": "2026-06-21T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -718,7 +700,7 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-20T10:45:00.000Z",
+          "scheduledTime": "2026-06-21T10:45:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -727,7 +709,7 @@
           "lineCode": "M-230",
           "lineName": "La Línea-San Roque",
           "destination": "La Línea de la Concepción",
-          "scheduledTime": "2026-06-20T10:45:00.000Z",
+          "scheduledTime": "2026-06-21T10:45:00.000Z",
           "direction": 2,
           "stopType": 1
         },
@@ -736,15 +718,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-06-20T11:00:00.000Z",
+          "scheduledTime": "2026-06-21T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -764,15 +746,15 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-06-20T10:33:00.000Z",
+          "scheduledTime": "2026-06-21T10:33:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -788,9 +770,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -806,9 +788,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -824,9 +806,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -842,9 +824,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T11:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T11:00:00.000Z"
       }
     },
     {
@@ -860,9 +842,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T12:30:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T12:30:00.000Z"
       }
     },
     {
@@ -881,17 +863,8 @@
           "lineId": "278",
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-20T10:28:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-20T10:35:00.000Z",
+          "scheduledTime": "2026-06-21T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -899,26 +872,26 @@
           "lineId": "283",
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
-          "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-20T11:00:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
-          "destination": "Fuensanta de Martos",
-          "scheduledTime": "2026-06-20T11:25:00.000Z",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-21T10:51:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "279",
-          "lineCode": "M20-02",
-          "lineName": "Jaén - Jamilena, 2024",
-          "destination": "Jamilena",
-          "scheduledTime": "2026-06-20T11:25:00.000Z",
+          "lineId": "289",
+          "lineCode": "M20-13",
+          "lineName": "Jaén - Jamilena - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-21T11:03:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "283",
+          "lineCode": "M20-06",
+          "lineName": "Jaén - Córdoba (Ruta), 2024",
+          "destination": "Torredonjimeno",
+          "scheduledTime": "2026-06-21T11:50:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -927,7 +900,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-20T11:55:00.000Z",
+          "scheduledTime": "2026-06-21T12:10:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -936,24 +909,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-20T12:08:00.000Z",
+          "scheduledTime": "2026-06-21T12:28:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "280",
-          "lineCode": "M20-03",
-          "lineName": "Jaén - Villardompardo, 2024",
-          "destination": "Villardompardo",
-          "scheduledTime": "2026-06-20T12:25:00.000Z",
-          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T12:30:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T12:30:00.000Z"
       }
     },
     {
@@ -969,11 +933,20 @@
       "nucleus": "Torredonjimeno",
       "services": [
         {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
+          "lineId": "283",
+          "lineCode": "M20-06",
+          "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-20T10:15:00.000Z",
+          "scheduledTime": "2026-06-21T10:38:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "289",
+          "lineCode": "M20-13",
+          "lineName": "Jaén - Jamilena - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-21T10:45:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -982,7 +955,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-20T10:48:00.000Z",
+          "scheduledTime": "2026-06-21T10:48:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -991,17 +964,8 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-20T11:13:00.000Z",
+          "scheduledTime": "2026-06-21T12:03:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
-          "destination": "Fuensanta de Martos",
-          "scheduledTime": "2026-06-20T11:38:00.000Z",
-          "direction": 2,
           "stopType": 0
         },
         {
@@ -1009,7 +973,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-20T11:55:00.000Z",
+          "scheduledTime": "2026-06-21T12:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1018,15 +982,15 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-20T12:08:00.000Z",
+          "scheduledTime": "2026-06-21T12:23:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T12:30:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T12:30:00.000Z"
       }
     },
     {
@@ -1045,34 +1009,16 @@
           "lineId": "203",
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-20T10:00:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "276",
-          "lineCode": "M15-7",
-          "lineName": "Jaén - Andújar - Marmolejo",
-          "destination": "Andújar",
-          "scheduledTime": "2026-06-20T10:55:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-20T11:00:00.000Z",
+          "scheduledTime": "2026-06-21T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T12:30:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T12:30:00.000Z"
       }
     },
     {
@@ -1086,39 +1032,11 @@
       },
       "municipality": "Mancha Real",
       "nucleus": "Mancha Real",
-      "services": [
-        {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-06-20T11:55:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "14",
-          "lineCode": "M1-5",
-          "lineName": "Quesada - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-06-20T12:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "22",
-          "lineCode": "M1-21",
-          "lineName": "Torres - Jaén",
-          "destination": "Torres",
-          "scheduledTime": "2026-06-20T12:25:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T12:30:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T12:30:00.000Z"
       }
     },
     {
@@ -1134,9 +1052,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-21T02:39:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-22T02:39:00.000Z"
       }
     },
     {
@@ -1152,9 +1070,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-21T02:39:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-22T02:39:00.000Z"
       }
     },
     {
@@ -1170,9 +1088,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-21T02:39:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-22T02:39:00.000Z"
       }
     },
     {
@@ -1188,9 +1106,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-21T02:39:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-22T02:39:00.000Z"
       }
     },
     {
@@ -1206,9 +1124,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-21T02:39:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-22T02:39:00.000Z"
       }
     },
     {
@@ -1228,7 +1146,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-20T10:03:00.000Z",
+          "scheduledTime": "2026-06-21T10:03:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1237,7 +1155,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-20T11:22:00.000Z",
+          "scheduledTime": "2026-06-21T11:22:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1246,7 +1164,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-20T12:03:00.000Z",
+          "scheduledTime": "2026-06-21T12:18:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1255,15 +1173,15 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-20T13:22:00.000Z",
+          "scheduledTime": "2026-06-21T13:22:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T14:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T14:00:00.000Z"
       }
     },
     {
@@ -1283,7 +1201,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-20T10:00:00.000Z",
+          "scheduledTime": "2026-06-21T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1292,7 +1210,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-20T11:20:00.000Z",
+          "scheduledTime": "2026-06-21T11:35:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1301,7 +1219,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-20T12:00:00.000Z",
+          "scheduledTime": "2026-06-21T12:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1310,7 +1228,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-20T13:20:00.000Z",
+          "scheduledTime": "2026-06-21T13:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1319,15 +1237,15 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-20T14:00:00.000Z",
+          "scheduledTime": "2026-06-21T14:00:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T14:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T14:00:00.000Z"
       }
     },
     {
@@ -1347,7 +1265,7 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-20T10:14:00.000Z",
+          "scheduledTime": "2026-06-21T10:14:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1356,25 +1274,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-20T10:18:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-20T11:03:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "50",
-          "lineCode": "M-407",
-          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
-          "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-06-20T12:47:00.000Z",
+          "scheduledTime": "2026-06-21T10:18:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1383,7 +1283,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-06-20T12:48:00.000Z",
+          "scheduledTime": "2026-06-21T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1392,24 +1292,15 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-20T13:33:00.000Z",
+          "scheduledTime": "2026-06-21T13:33:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "50",
-          "lineCode": "M-407",
-          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-20T13:47:00.000Z",
-          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T14:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T14:00:00.000Z"
       }
     },
     {
@@ -1425,9 +1316,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T14:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T14:00:00.000Z"
       }
     },
     {
@@ -1443,9 +1334,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-20T06:35:17.558Z",
-        "startTime": "2026-06-20T10:00:00.000Z",
-        "endTime": "2026-06-20T14:00:00.000Z"
+        "requestedAt": "2026-06-21T06:37:29.283Z",
+        "startTime": "2026-06-21T10:00:00.000Z",
+        "endTime": "2026-06-21T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:08.640Z",
+    "generatedAt": "2026-06-21T06:37:21.303Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:08.640Z",
+    "generatedAt": "2026-06-21T06:37:21.303Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:08.640Z",
+    "generatedAt": "2026-06-21T06:37:21.303Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:08.640Z",
+    "generatedAt": "2026-06-21T06:37:21.303Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:08.640Z",
+    "generatedAt": "2026-06-21T06:37:21.303Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:08.640Z",
+    "generatedAt": "2026-06-21T06:37:21.303Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:08.640Z",
+    "generatedAt": "2026-06-21T06:37:21.303Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:08.640Z",
+    "generatedAt": "2026-06-21T06:37:21.303Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:08.640Z",
+    "generatedAt": "2026-06-21T06:37:21.303Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-20T06:35:08.640Z",
+    "generatedAt": "2026-06-21T06:37:21.303Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-06-21 06:38 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refreshed data catalog and stop directory metadata with updated generation timestamps across all consortiums.
  * Updated stop services snapshot with current service information, retrieval timestamps, and schedule data.
  * Revised route line data for one route group, updating item count and service entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->