### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,
     "consortiumName": "Área de Málaga",
-    "itemCount": 100
+    "itemCount": 99
   },
   "lines": [
     {
@@ -838,31 +838,6 @@
       "modeId": "1",
       "operators": [
         "Autocares Vázquez Olmedo",
-        "S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "314",
-      "code": "M-165",
-      "name": "La Cala del Moral-El Palo",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Avanza Movilidad Integral",
         "S.L."
       ],
       "hasNews": false,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:25.360Z",
+    "generatedAt": "2026-06-22T06:50:53.309Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:29.283Z",
+    "generatedAt": "2026-06-22T06:50:58.085Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -17,11 +17,30 @@
       },
       "municipality": "DOS HERMANAS",
       "nucleus": "FUENTE DEL REY (Dos Hermanas) zonaC",
-      "services": [],
+      "services": [
+        {
+          "lineId": "242",
+          "lineCode": "1320",
+          "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-06-22T10:07:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "242",
+          "lineCode": "1320",
+          "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-06-22T10:37:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -37,19 +56,46 @@
       "nucleus": "ESPARTINAS",
       "services": [
         {
+          "lineId": "284",
+          "lineCode": "1666",
+          "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-06-22T10:31:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
           "lineId": "295",
           "lineCode": "1681",
           "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-21T10:27:00.000Z",
+          "scheduledTime": "2026-06-22T10:42:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "290",
+          "lineCode": "1020",
+          "lineName": "M-102A Circular Aljarafe (sentido A)",
+          "destination": "SANLUCAR LA MAYOR",
+          "scheduledTime": "2026-06-22T10:46:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "279",
+          "lineCode": "1661",
+          "lineName": "M-166 Sanlúcar la Mayor - Sevilla",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-06-22T10:48:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -69,15 +115,24 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-21T10:02:00.000Z",
+          "scheduledTime": "2026-06-22T10:02:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "287",
+          "lineCode": "1720",
+          "lineName": "M-170A Santiponce - Sevilla",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-06-22T10:32:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -93,9 +148,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -115,7 +170,7 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-21T10:04:00.000Z",
+          "scheduledTime": "2026-06-22T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -124,15 +179,24 @@
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-06-21T10:04:00.000Z",
+          "scheduledTime": "2026-06-22T10:04:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "232",
+          "lineCode": "1100",
+          "lineName": "M-110 La Algaba - Sevilla",
+          "destination": "LA ALGABA",
+          "scheduledTime": "2026-06-22T10:34:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -148,9 +212,9 @@
       "nucleus": "Penal",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -166,9 +230,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -184,46 +248,37 @@
       "nucleus": "Sanlúcar de Barrameda",
       "services": [
         {
-          "lineId": "163",
-          "lineCode": "M-960",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
+          "lineId": "225",
+          "lineCode": "M-967",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-21T10:05:00.000Z",
+          "scheduledTime": "2026-06-22T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "230",
-          "lineCode": "M-965",
-          "lineName": "Chipiona-Sanlúcar De Barrameda (Sevilla/Utrera)",
+          "lineId": "225",
+          "lineCode": "M-967",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-21T10:11:00.000Z",
+          "scheduledTime": "2026-06-22T10:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "231",
-          "lineCode": "M-974",
-          "lineName": "Costa Ballena-Chipiona-Sanlúcar De Barrameda (Sevilla)",
-          "destination": "Costa Ballena (Rota)",
-          "scheduledTime": "2026-06-21T10:12:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "172",
-          "lineCode": "M-561",
-          "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
+          "lineId": "166",
+          "lineCode": "M-963",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera",
           "destination": "Jerez",
-          "scheduledTime": "2026-06-21T10:45:00.000Z",
+          "scheduledTime": "2026-06-22T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -237,11 +292,30 @@
       },
       "municipality": "Chiclana",
       "nucleus": "Chiclana",
-      "services": [],
+      "services": [
+        {
+          "lineId": "26",
+          "lineCode": "M-230",
+          "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
+          "destination": "Hospital Pto. Real",
+          "scheduledTime": "2026-06-22T10:16:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "26",
+          "lineCode": "M-230",
+          "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
+          "destination": "Chiclana",
+          "scheduledTime": "2026-06-22T10:44:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -260,8 +334,17 @@
           "lineId": "6",
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
+          "destination": "Hospital Pto. Real",
+          "scheduledTime": "2026-06-22T10:05:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "6",
+          "lineCode": "M-030",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-21T10:10:00.000Z",
+          "scheduledTime": "2026-06-22T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -270,7 +353,25 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-21T10:21:00.000Z",
+          "scheduledTime": "2026-06-22T10:21:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "6",
+          "lineCode": "M-030",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
+          "destination": "Hospital Pto. Real",
+          "scheduledTime": "2026-06-22T10:35:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "6",
+          "lineCode": "M-030",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
+          "destination": "Cádiz",
+          "scheduledTime": "2026-06-22T10:40:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -279,24 +380,24 @@
           "lineCode": "M-031",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
           "destination": "Puerto Real",
-          "scheduledTime": "2026-06-21T10:31:00.000Z",
+          "scheduledTime": "2026-06-22T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "9",
-          "lineCode": "M-031",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
+          "lineId": "6",
+          "lineCode": "M-030",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-21T10:52:00.000Z",
+          "scheduledTime": "2026-06-22T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -316,24 +417,69 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-21T10:21:00.000Z",
+          "scheduledTime": "2026-06-22T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
         {
-          "lineId": "992",
-          "lineCode": "0226",
-          "lineName": "Granada - P.Puente - Zujaira",
-          "destination": "Zujaira",
-          "scheduledTime": "2026-06-21T11:49:00.000Z",
+          "lineId": "1077",
+          "lineCode": "0124",
+          "lineName": "Granada - Atarfe",
+          "destination": "Atarfe",
+          "scheduledTime": "2026-06-22T10:28:00.000Z",
+          "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "991",
+          "lineCode": "0225",
+          "lineName": "Granada - P.Puente",
+          "destination": "Pinos Puente",
+          "scheduledTime": "2026-06-22T10:51:00.000Z",
+          "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "1077",
+          "lineCode": "0124",
+          "lineName": "Granada - Atarfe",
+          "destination": "Atarfe",
+          "scheduledTime": "2026-06-22T11:08:00.000Z",
+          "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "991",
+          "lineCode": "0225",
+          "lineName": "Granada - P.Puente",
+          "destination": "Pinos Puente",
+          "scheduledTime": "2026-06-22T11:21:00.000Z",
+          "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "1077",
+          "lineCode": "0124",
+          "lineName": "Granada - Atarfe",
+          "destination": "Atarfe",
+          "scheduledTime": "2026-06-22T11:48:00.000Z",
+          "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "991",
+          "lineCode": "0225",
+          "lineName": "Granada - P.Puente",
+          "destination": "Pinos Puente",
+          "scheduledTime": "2026-06-22T11:51:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T12:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T12:00:00.000Z"
       }
     },
     {
@@ -352,8 +498,17 @@
           "lineId": "1032",
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
-          "destination": "Centro Penitenciario de Albolote",
-          "scheduledTime": "2026-06-21T10:00:00.000Z",
+          "destination": "Granada",
+          "scheduledTime": "2026-06-22T10:39:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "710",
+          "lineCode": "0318",
+          "lineName": "Granada - Colomera",
+          "destination": "Cerro Cauro",
+          "scheduledTime": "2026-06-22T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -361,25 +516,16 @@
           "lineId": "1032",
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
-          "destination": "Granada",
-          "scheduledTime": "2026-06-21T10:54:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "1032",
-          "lineCode": "0117",
-          "lineName": "Granada - P.Cubillas",
-          "destination": "Centro Penitenciario de Albolote",
-          "scheduledTime": "2026-06-21T11:30:00.000Z",
+          "destination": "Parque del Cubillas",
+          "scheduledTime": "2026-06-22T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T12:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T12:00:00.000Z"
       }
     },
     {
@@ -395,19 +541,37 @@
       "nucleus": "Chauchina",
       "services": [
         {
+          "lineId": "868",
+          "lineCode": "0241",
+          "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
+          "destination": "Cijuela",
+          "scheduledTime": "2026-06-22T10:26:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
           "lineId": "1119",
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-21T11:27:00.000Z",
+          "scheduledTime": "2026-06-22T11:27:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "1119",
+          "lineCode": "0242",
+          "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
+          "destination": "Láchar",
+          "scheduledTime": "2026-06-22T11:57:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T12:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T12:00:00.000Z"
       }
     },
     {
@@ -421,11 +585,21 @@
       },
       "municipality": "Cijuela",
       "nucleus": "Cijuela",
-      "services": [],
+      "services": [
+        {
+          "lineId": "877",
+          "lineCode": "0340",
+          "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
+          "destination": "Granada",
+          "scheduledTime": "2026-06-22T11:01:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T12:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T12:00:00.000Z"
       }
     },
     {
@@ -441,29 +615,11 @@
       "nucleus": "Ambroz",
       "services": [
         {
-          "lineId": "1042",
-          "lineCode": "0154",
-          "lineName": "Granada-V. del Genil (Directo)",
-          "destination": "Granada",
-          "scheduledTime": "2026-06-21T10:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
           "lineId": "1113",
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-21T10:01:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1042",
-          "lineCode": "0154",
-          "lineName": "Granada-V. del Genil (Directo)",
-          "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-21T10:45:00.000Z",
+          "scheduledTime": "2026-06-22T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -472,7 +628,34 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-21T11:15:00.000Z",
+          "scheduledTime": "2026-06-22T10:30:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "1042",
+          "lineCode": "0154",
+          "lineName": "Granada-V. del Genil (Directo)",
+          "destination": "El Ventorrillo",
+          "scheduledTime": "2026-06-22T10:35:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "1042",
+          "lineCode": "0154",
+          "lineName": "Granada-V. del Genil (Directo)",
+          "destination": "El Ventorrillo",
+          "scheduledTime": "2026-06-22T11:15:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "1042",
+          "lineCode": "0154",
+          "lineName": "Granada-V. del Genil (Directo)",
+          "destination": "Granada",
+          "scheduledTime": "2026-06-22T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -481,15 +664,24 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-21T11:31:00.000Z",
+          "scheduledTime": "2026-06-22T11:46:00.000Z",
           "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "1042",
+          "lineCode": "0154",
+          "lineName": "Granada-V. del Genil (Directo)",
+          "destination": "Granada",
+          "scheduledTime": "2026-06-22T11:55:00.000Z",
+          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T12:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T12:00:00.000Z"
       }
     },
     {
@@ -503,11 +695,21 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [],
+      "services": [
+        {
+          "lineId": "99",
+          "lineCode": "M-250",
+          "lineName": "Málaga-Almogía",
+          "destination": "Málaga",
+          "scheduledTime": "2026-06-22T10:11:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T10:15:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T10:15:00.000Z"
       }
     },
     {
@@ -521,11 +723,21 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [],
+      "services": [
+        {
+          "lineId": "99",
+          "lineCode": "M-250",
+          "lineName": "Málaga-Almogía",
+          "destination": "Málaga",
+          "scheduledTime": "2026-06-22T10:08:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T10:15:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T10:15:00.000Z"
       }
     },
     {
@@ -541,9 +753,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T10:15:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T10:15:00.000Z"
       }
     },
     {
@@ -557,11 +769,21 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [],
+      "services": [
+        {
+          "lineId": "99",
+          "lineCode": "M-250",
+          "lineName": "Málaga-Almogía",
+          "destination": "Málaga",
+          "scheduledTime": "2026-06-22T10:05:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T10:15:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T10:15:00.000Z"
       }
     },
     {
@@ -575,11 +797,21 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [],
+      "services": [
+        {
+          "lineId": "99",
+          "lineCode": "M-250",
+          "lineName": "Málaga-Almogía",
+          "destination": "Málaga",
+          "scheduledTime": "2026-06-22T10:02:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T10:15:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T10:15:00.000Z"
       }
     },
     {
@@ -595,9 +827,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -613,9 +845,9 @@
       "nucleus": "Tarifa",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -634,25 +866,25 @@
           "lineId": "1",
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
-          "destination": "Algeciras",
-          "scheduledTime": "2026-06-21T10:30:00.000Z",
-          "direction": 1,
+          "destination": "Los Barrios",
+          "scheduledTime": "2026-06-22T10:30:00.000Z",
+          "direction": 2,
           "stopType": 0
         },
         {
           "lineId": "1",
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
-          "destination": "Los Barrios",
-          "scheduledTime": "2026-06-21T10:30:00.000Z",
-          "direction": 2,
+          "destination": "Algeciras",
+          "scheduledTime": "2026-06-22T10:30:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -672,15 +904,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-21T10:03:00.000Z",
+          "scheduledTime": "2026-06-22T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -700,17 +932,8 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-21T10:45:00.000Z",
+          "scheduledTime": "2026-06-22T10:45:00.000Z",
           "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "11",
-          "lineCode": "M-230",
-          "lineName": "La Línea-San Roque",
-          "destination": "La Línea de la Concepción",
-          "scheduledTime": "2026-06-21T10:45:00.000Z",
-          "direction": 2,
           "stopType": 1
         },
         {
@@ -718,15 +941,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-06-21T11:00:00.000Z",
+          "scheduledTime": "2026-06-22T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -745,16 +968,34 @@
           "lineId": "40",
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
+          "destination": "ADRA",
+          "scheduledTime": "2026-06-22T10:36:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "40",
+          "lineCode": "M-380",
+          "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-06-21T10:33:00.000Z",
+          "scheduledTime": "2026-06-22T10:48:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "48",
+          "lineCode": "M-384",
+          "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
+          "destination": "ADRA",
+          "scheduledTime": "2026-06-22T10:51:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -770,9 +1011,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -788,9 +1029,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -806,9 +1047,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -824,9 +1065,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T11:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T11:00:00.000Z"
       }
     },
     {
@@ -842,9 +1083,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T12:30:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T12:30:00.000Z"
       }
     },
     {
@@ -860,11 +1101,56 @@
       "nucleus": "Torredelcampo",
       "services": [
         {
+          "lineId": "279",
+          "lineCode": "M20-02",
+          "lineName": "Jaén - Jamilena, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-22T10:13:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
           "lineId": "278",
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-21T10:35:00.000Z",
+          "scheduledTime": "2026-06-22T10:20:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "286",
+          "lineCode": "M20-10",
+          "lineName": "Jaén - Torredelcampo, 2024",
+          "destination": "Torredelcampo",
+          "scheduledTime": "2026-06-22T10:25:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-22T10:28:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "286",
+          "lineCode": "M20-10",
+          "lineName": "Jaén - Torredelcampo, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-22T10:33:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "287",
+          "lineCode": "M20-11",
+          "lineName": "Fuensanta de Martos - Jaén, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-22T10:38:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -872,26 +1158,71 @@
           "lineId": "283",
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-21T10:51:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "289",
-          "lineCode": "M20-13",
-          "lineName": "Jaén - Jamilena - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-21T11:03:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "283",
-          "lineCode": "M20-06",
-          "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-21T11:50:00.000Z",
+          "scheduledTime": "2026-06-22T10:40:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-06-22T11:05:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-06-22T11:20:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "286",
+          "lineCode": "M20-10",
+          "lineName": "Jaén - Torredelcampo, 2024",
+          "destination": "Torredelcampo",
+          "scheduledTime": "2026-06-22T11:25:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-22T11:28:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "288",
+          "lineCode": "M20-12",
+          "lineName": "Jaén - Escañuela, 2024",
+          "destination": "Escañuela",
+          "scheduledTime": "2026-06-22T11:55:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "285",
+          "lineCode": "M20-08",
+          "lineName": "Jaén - Lopera, 2024",
+          "destination": "Torredonjimeno",
+          "scheduledTime": "2026-06-22T12:20:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-06-22T12:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -900,7 +1231,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-21T12:10:00.000Z",
+          "scheduledTime": "2026-06-22T12:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -909,15 +1240,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-21T12:28:00.000Z",
+          "scheduledTime": "2026-06-22T12:28:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T12:30:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T12:30:00.000Z"
       }
     },
     {
@@ -933,21 +1264,21 @@
       "nucleus": "Torredonjimeno",
       "services": [
         {
-          "lineId": "283",
-          "lineCode": "M20-06",
-          "lineName": "Jaén - Córdoba (Ruta), 2024",
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-21T10:38:00.000Z",
+          "scheduledTime": "2026-06-22T10:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "289",
-          "lineCode": "M20-13",
-          "lineName": "Jaén - Jamilena - Martos, 2024",
+          "lineId": "287",
+          "lineCode": "M20-11",
+          "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-21T10:45:00.000Z",
-          "direction": 2,
+          "scheduledTime": "2026-06-22T10:25:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
@@ -955,7 +1286,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-21T10:48:00.000Z",
+          "scheduledTime": "2026-06-22T10:33:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -964,7 +1295,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-21T12:03:00.000Z",
+          "scheduledTime": "2026-06-22T10:53:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -973,24 +1304,51 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-21T12:15:00.000Z",
+          "scheduledTime": "2026-06-22T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "281",
-          "lineCode": "M20-04",
-          "lineName": "Jaén - Alcaudete, 2024",
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-21T12:23:00.000Z",
+          "scheduledTime": "2026-06-22T11:18:00.000Z",
           "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-06-22T11:33:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "288",
+          "lineCode": "M20-12",
+          "lineName": "Jaén - Escañuela, 2024",
+          "destination": "Escañuela",
+          "scheduledTime": "2026-06-22T12:08:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-22T12:15:00.000Z",
+          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T12:30:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T12:30:00.000Z"
       }
     },
     {
@@ -1006,19 +1364,82 @@
       "nucleus": "Mengíbar",
       "services": [
         {
+          "lineId": "71",
+          "lineCode": "M16-1",
+          "lineName": "Santa Elena - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-22T10:05:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
           "lineId": "203",
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-21T11:00:00.000Z",
+          "scheduledTime": "2026-06-22T10:10:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "71",
+          "lineCode": "M16-1",
+          "lineName": "Santa Elena - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-06-22T10:15:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "203",
+          "lineCode": "M04-8",
+          "lineName": "Linares - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-22T10:45:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "203",
+          "lineCode": "M04-8",
+          "lineName": "Linares - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-06-22T11:00:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "71",
+          "lineCode": "M16-1",
+          "lineName": "Santa Elena - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-06-22T11:25:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "203",
+          "lineCode": "M04-8",
+          "lineName": "Linares - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-22T11:30:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "203",
+          "lineCode": "M04-8",
+          "lineName": "Linares - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-06-22T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T12:30:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T12:30:00.000Z"
       }
     },
     {
@@ -1032,11 +1453,57 @@
       },
       "municipality": "Mancha Real",
       "nucleus": "Mancha Real",
-      "services": [],
+      "services": [
+        {
+          "lineId": "17",
+          "lineCode": "M1-9",
+          "lineName": "Mancha Real - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-22T10:45:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "35",
+          "lineCode": "M3-103",
+          "lineName": "Úbeda - Jaén",
+          "destination": "Mancha Real",
+          "scheduledTime": "2026-06-22T11:00:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "17",
+          "lineCode": "M1-9",
+          "lineName": "Mancha Real - Jaén",
+          "destination": "Mancha Real",
+          "scheduledTime": "2026-06-22T11:25:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "21",
+          "lineCode": "M1-20",
+          "lineName": "Pozo Alcón - Jaén",
+          "destination": "Mancha Real",
+          "scheduledTime": "2026-06-22T12:00:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "14",
+          "lineCode": "M1-5",
+          "lineName": "Quesada - Jaén",
+          "destination": "Mancha Real",
+          "scheduledTime": "2026-06-22T12:00:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T12:30:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T12:30:00.000Z"
       }
     },
     {
@@ -1052,9 +1519,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-22T02:39:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-23T02:39:00.000Z"
       }
     },
     {
@@ -1070,9 +1537,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-22T02:39:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-23T02:39:00.000Z"
       }
     },
     {
@@ -1088,9 +1555,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-22T02:39:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-23T02:39:00.000Z"
       }
     },
     {
@@ -1106,9 +1573,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-22T02:39:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-23T02:39:00.000Z"
       }
     },
     {
@@ -1124,9 +1591,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-22T02:39:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-23T02:39:00.000Z"
       }
     },
     {
@@ -1142,46 +1609,109 @@
       "nucleus": "LEPE",
       "services": [
         {
-          "lineId": "76",
-          "lineCode": "M-912",
-          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-21T10:03:00.000Z",
+          "scheduledTime": "2026-06-22T10:05:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "76",
-          "lineCode": "M-912",
-          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
-          "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-21T11:22:00.000Z",
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-06-22T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "76",
-          "lineCode": "M-912",
-          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "lineId": "5",
+          "lineCode": "M-310",
+          "lineName": "Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-21T12:18:00.000Z",
+          "scheduledTime": "2026-06-22T11:34:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "76",
-          "lineCode": "M-912",
-          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "lineId": "66",
+          "lineCode": "M-902",
+          "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-21T13:22:00.000Z",
+          "scheduledTime": "2026-06-22T11:36:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "3",
+          "lineCode": "M-306",
+          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-06-22T11:44:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "3",
+          "lineCode": "M-306",
+          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-06-22T12:06:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "8",
+          "lineCode": "M-316",
+          "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
+          "destination": "VILLABLANCA",
+          "scheduledTime": "2026-06-22T12:36:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "8",
+          "lineCode": "M-316",
+          "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
+          "destination": "VILLABLANCA",
+          "scheduledTime": "2026-06-22T12:36:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "66",
+          "lineCode": "M-902",
+          "lineName": "Ayamonte-Huelva-Sevilla",
+          "destination": "AYAMONTE",
+          "scheduledTime": "2026-06-22T13:36:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-06-22T13:41:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "66",
+          "lineCode": "M-902",
+          "lineName": "Ayamonte-Huelva-Sevilla",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-06-22T13:52:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T14:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T14:00:00.000Z"
       }
     },
     {
@@ -1197,55 +1727,73 @@
       "nucleus": "ISLA CRISTINA",
       "services": [
         {
-          "lineId": "76",
-          "lineCode": "M-912",
-          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "lineId": "7",
+          "lineCode": "M-314",
+          "lineName": "Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-21T10:00:00.000Z",
+          "scheduledTime": "2026-06-22T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "76",
-          "lineCode": "M-912",
-          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "lineId": "5",
+          "lineCode": "M-310",
+          "lineName": "Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-21T11:35:00.000Z",
+          "scheduledTime": "2026-06-22T11:14:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "76",
-          "lineCode": "M-912",
-          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
-          "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-21T12:00:00.000Z",
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-06-22T11:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "76",
-          "lineCode": "M-912",
-          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "lineId": "3",
+          "lineCode": "M-306",
+          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-21T13:20:00.000Z",
+          "scheduledTime": "2026-06-22T11:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "76",
-          "lineCode": "M-912",
-          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "lineId": "7",
+          "lineCode": "M-314",
+          "lineName": "Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-21T14:00:00.000Z",
+          "scheduledTime": "2026-06-22T11:30:00.000Z",
           "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "3",
+          "lineCode": "M-306",
+          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-06-22T12:29:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-06-22T13:20:00.000Z",
+          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T14:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T14:00:00.000Z"
       }
     },
     {
@@ -1261,20 +1809,11 @@
       "nucleus": "ALMONTE",
       "services": [
         {
-          "lineId": "75",
-          "lineCode": "M-911",
-          "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
-          "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-21T10:14:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-21T10:18:00.000Z",
+          "lineId": "70",
+          "lineCode": "M-906",
+          "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
+          "destination": "ROCIANA DEL CONDADO",
+          "scheduledTime": "2026-06-22T12:28:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1283,7 +1822,25 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-06-21T10:48:00.000Z",
+          "scheduledTime": "2026-06-22T12:33:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "48",
+          "lineCode": "M-405",
+          "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
+          "destination": "BOLLULLOS PAR DEL CONDADO",
+          "scheduledTime": "2026-06-22T12:36:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "50",
+          "lineCode": "M-407",
+          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-06-22T13:17:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1292,15 +1849,15 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-21T13:33:00.000Z",
+          "scheduledTime": "2026-06-22T13:33:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T14:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T14:00:00.000Z"
       }
     },
     {
@@ -1316,9 +1873,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T14:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T14:00:00.000Z"
       }
     },
     {
@@ -1334,9 +1891,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-21T06:37:29.283Z",
-        "startTime": "2026-06-21T10:00:00.000Z",
-        "endTime": "2026-06-21T14:00:00.000Z"
+        "requestedAt": "2026-06-22T06:50:58.085Z",
+        "startTime": "2026-06-22T10:00:00.000Z",
+        "endTime": "2026-06-22T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:21.303Z",
+    "generatedAt": "2026-06-22T06:50:48.817Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:21.303Z",
+    "generatedAt": "2026-06-22T06:50:48.817Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:21.303Z",
+    "generatedAt": "2026-06-22T06:50:48.817Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:21.303Z",
+    "generatedAt": "2026-06-22T06:50:48.817Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:21.303Z",
+    "generatedAt": "2026-06-22T06:50:48.817Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:21.303Z",
+    "generatedAt": "2026-06-22T06:50:48.817Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:21.303Z",
+    "generatedAt": "2026-06-22T06:50:48.817Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:21.303Z",
+    "generatedAt": "2026-06-22T06:50:48.817Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:21.303Z",
+    "generatedAt": "2026-06-22T06:50:48.817Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-21T06:37:21.303Z",
+    "generatedAt": "2026-06-22T06:50:48.817Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-06-22 06:51 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated catalog metadata and timestamps across all consortiums.
  * Refreshed transit service schedules and departure predictions in snapshot data.
  * Removed one transit line from the catalog.
  * Updated stop directory data with new generation timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->