### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,
     "consortiumName": "Bahía de Cádiz",
-    "itemCount": 64
+    "itemCount": 62
   },
   "lines": [
     {
@@ -1461,54 +1461,6 @@
       "modeId": "1",
       "operators": [
         "Transportes Generales Comes S.A."
-      ],
-      "hasNews": true,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "170",
-      "code": "M-972",
-      "name": "Sanlúcar De Barrameda-Campus De Jerez",
-      "mode": "AUTOBUS",
-      "modeId": "1",
-      "operators": [
-        "Empresa Monforte S.A.U."
-      ],
-      "hasNews": true,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "168",
-      "code": "M-970",
-      "name": "Sanlúcar De Barrameda-Jerez De La Frontera",
-      "mode": "AUTOBUS",
-      "modeId": "1",
-      "operators": [
-        "Empresa Monforte S.A.U."
       ],
       "hasNews": true,
       "concession": null,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:53.309Z",
+    "generatedAt": "2026-06-23T06:26:20.308Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:58.085Z",
+    "generatedAt": "2026-06-23T06:26:23.794Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -23,7 +23,7 @@
           "lineCode": "1320",
           "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-22T10:07:00.000Z",
+          "scheduledTime": "2026-06-23T10:07:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -32,15 +32,15 @@
           "lineCode": "1320",
           "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-22T10:37:00.000Z",
+          "scheduledTime": "2026-06-23T10:37:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -60,7 +60,7 @@
           "lineCode": "1666",
           "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-22T10:31:00.000Z",
+          "scheduledTime": "2026-06-23T10:31:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -69,7 +69,7 @@
           "lineCode": "1681",
           "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-22T10:42:00.000Z",
+          "scheduledTime": "2026-06-23T10:42:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -78,7 +78,7 @@
           "lineCode": "1020",
           "lineName": "M-102A Circular Aljarafe (sentido A)",
           "destination": "SANLUCAR LA MAYOR",
-          "scheduledTime": "2026-06-22T10:46:00.000Z",
+          "scheduledTime": "2026-06-23T10:46:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -87,15 +87,15 @@
           "lineCode": "1661",
           "lineName": "M-166 Sanlúcar la Mayor - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-22T10:48:00.000Z",
+          "scheduledTime": "2026-06-23T10:48:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -115,7 +115,7 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-22T10:02:00.000Z",
+          "scheduledTime": "2026-06-23T10:02:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -124,15 +124,15 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-22T10:32:00.000Z",
+          "scheduledTime": "2026-06-23T10:32:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -148,9 +148,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -170,7 +170,7 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-22T10:04:00.000Z",
+          "scheduledTime": "2026-06-23T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -179,7 +179,7 @@
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-06-22T10:04:00.000Z",
+          "scheduledTime": "2026-06-23T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -188,15 +188,15 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-22T10:34:00.000Z",
+          "scheduledTime": "2026-06-23T10:34:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -212,9 +212,9 @@
       "nucleus": "Penal",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -230,9 +230,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -252,7 +252,7 @@
           "lineCode": "M-967",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-22T10:05:00.000Z",
+          "scheduledTime": "2026-06-23T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -261,24 +261,15 @@
           "lineCode": "M-967",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-22T10:28:00.000Z",
+          "scheduledTime": "2026-06-23T10:28:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "166",
-          "lineCode": "M-963",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera",
-          "destination": "Jerez",
-          "scheduledTime": "2026-06-22T10:45:00.000Z",
-          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -298,7 +289,7 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-22T10:16:00.000Z",
+          "scheduledTime": "2026-06-23T10:16:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -307,15 +298,15 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Chiclana",
-          "scheduledTime": "2026-06-22T10:44:00.000Z",
+          "scheduledTime": "2026-06-23T10:44:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -335,7 +326,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-22T10:05:00.000Z",
+          "scheduledTime": "2026-06-23T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -344,7 +335,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-22T10:10:00.000Z",
+          "scheduledTime": "2026-06-23T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -353,7 +344,7 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-22T10:21:00.000Z",
+          "scheduledTime": "2026-06-23T10:21:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -362,7 +353,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-22T10:35:00.000Z",
+          "scheduledTime": "2026-06-23T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -371,7 +362,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-22T10:40:00.000Z",
+          "scheduledTime": "2026-06-23T10:40:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -380,7 +371,7 @@
           "lineCode": "M-031",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
           "destination": "Puerto Real",
-          "scheduledTime": "2026-06-22T10:51:00.000Z",
+          "scheduledTime": "2026-06-23T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -389,15 +380,15 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-22T11:00:00.000Z",
+          "scheduledTime": "2026-06-23T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -417,7 +408,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-22T10:21:00.000Z",
+          "scheduledTime": "2026-06-23T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -426,7 +417,7 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-06-22T10:28:00.000Z",
+          "scheduledTime": "2026-06-23T10:28:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -435,7 +426,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-22T10:51:00.000Z",
+          "scheduledTime": "2026-06-23T10:51:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -444,7 +435,7 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-06-22T11:08:00.000Z",
+          "scheduledTime": "2026-06-23T11:08:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -453,7 +444,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-22T11:21:00.000Z",
+          "scheduledTime": "2026-06-23T11:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -462,7 +453,7 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-06-22T11:48:00.000Z",
+          "scheduledTime": "2026-06-23T11:48:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -471,15 +462,15 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-22T11:51:00.000Z",
+          "scheduledTime": "2026-06-23T11:51:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T12:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T12:00:00.000Z"
       }
     },
     {
@@ -499,7 +490,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Granada",
-          "scheduledTime": "2026-06-22T10:39:00.000Z",
+          "scheduledTime": "2026-06-23T10:39:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -508,7 +499,7 @@
           "lineCode": "0318",
           "lineName": "Granada - Colomera",
           "destination": "Cerro Cauro",
-          "scheduledTime": "2026-06-22T10:41:00.000Z",
+          "scheduledTime": "2026-06-23T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -517,15 +508,15 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Parque del Cubillas",
-          "scheduledTime": "2026-06-22T11:30:00.000Z",
+          "scheduledTime": "2026-06-23T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T12:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T12:00:00.000Z"
       }
     },
     {
@@ -545,7 +536,7 @@
           "lineCode": "0241",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
           "destination": "Cijuela",
-          "scheduledTime": "2026-06-22T10:26:00.000Z",
+          "scheduledTime": "2026-06-23T10:26:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -554,7 +545,7 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-22T11:27:00.000Z",
+          "scheduledTime": "2026-06-23T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -563,15 +554,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-22T11:57:00.000Z",
+          "scheduledTime": "2026-06-23T11:57:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T12:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T12:00:00.000Z"
       }
     },
     {
@@ -591,15 +582,15 @@
           "lineCode": "0340",
           "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
           "destination": "Granada",
-          "scheduledTime": "2026-06-22T11:01:00.000Z",
+          "scheduledTime": "2026-06-23T11:01:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T12:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T12:00:00.000Z"
       }
     },
     {
@@ -619,7 +610,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-22T10:01:00.000Z",
+          "scheduledTime": "2026-06-23T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -628,7 +619,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-22T10:30:00.000Z",
+          "scheduledTime": "2026-06-23T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -637,7 +628,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-22T10:35:00.000Z",
+          "scheduledTime": "2026-06-23T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -646,7 +637,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-22T11:15:00.000Z",
+          "scheduledTime": "2026-06-23T11:15:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -655,7 +646,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-22T11:15:00.000Z",
+          "scheduledTime": "2026-06-23T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -664,7 +655,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-22T11:46:00.000Z",
+          "scheduledTime": "2026-06-23T11:46:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -673,15 +664,15 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-22T11:55:00.000Z",
+          "scheduledTime": "2026-06-23T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T12:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T12:00:00.000Z"
       }
     },
     {
@@ -701,15 +692,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-22T10:11:00.000Z",
+          "scheduledTime": "2026-06-23T10:11:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T10:15:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T10:15:00.000Z"
       }
     },
     {
@@ -729,15 +720,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-22T10:08:00.000Z",
+          "scheduledTime": "2026-06-23T10:08:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T10:15:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T10:15:00.000Z"
       }
     },
     {
@@ -753,9 +744,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T10:15:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T10:15:00.000Z"
       }
     },
     {
@@ -775,15 +766,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-22T10:05:00.000Z",
+          "scheduledTime": "2026-06-23T10:05:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T10:15:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T10:15:00.000Z"
       }
     },
     {
@@ -803,15 +794,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-22T10:02:00.000Z",
+          "scheduledTime": "2026-06-23T10:02:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T10:15:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T10:15:00.000Z"
       }
     },
     {
@@ -827,9 +818,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -845,9 +836,9 @@
       "nucleus": "Tarifa",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -867,7 +858,7 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-22T10:30:00.000Z",
+          "scheduledTime": "2026-06-23T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -876,15 +867,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-22T10:30:00.000Z",
+          "scheduledTime": "2026-06-23T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -904,15 +895,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-22T10:03:00.000Z",
+          "scheduledTime": "2026-06-23T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -932,7 +923,7 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-22T10:45:00.000Z",
+          "scheduledTime": "2026-06-23T10:45:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -941,15 +932,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-06-22T11:00:00.000Z",
+          "scheduledTime": "2026-06-23T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -969,7 +960,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ADRA",
-          "scheduledTime": "2026-06-22T10:36:00.000Z",
+          "scheduledTime": "2026-06-23T10:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -978,7 +969,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-06-22T10:48:00.000Z",
+          "scheduledTime": "2026-06-23T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -987,15 +978,15 @@
           "lineCode": "M-384",
           "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
           "destination": "ADRA",
-          "scheduledTime": "2026-06-22T10:51:00.000Z",
+          "scheduledTime": "2026-06-23T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -1011,9 +1002,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -1029,9 +1020,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -1047,9 +1038,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -1065,9 +1056,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T11:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T11:00:00.000Z"
       }
     },
     {
@@ -1083,9 +1074,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T12:30:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T12:30:00.000Z"
       }
     },
     {
@@ -1105,7 +1096,7 @@
           "lineCode": "M20-02",
           "lineName": "Jaén - Jamilena, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T10:13:00.000Z",
+          "scheduledTime": "2026-06-23T10:13:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1114,7 +1105,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-22T10:20:00.000Z",
+          "scheduledTime": "2026-06-23T10:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1123,7 +1114,7 @@
           "lineCode": "M20-10",
           "lineName": "Jaén - Torredelcampo, 2024",
           "destination": "Torredelcampo",
-          "scheduledTime": "2026-06-22T10:25:00.000Z",
+          "scheduledTime": "2026-06-23T10:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1132,7 +1123,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T10:28:00.000Z",
+          "scheduledTime": "2026-06-23T10:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1141,7 +1132,7 @@
           "lineCode": "M20-10",
           "lineName": "Jaén - Torredelcampo, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T10:33:00.000Z",
+          "scheduledTime": "2026-06-23T10:33:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1150,7 +1141,7 @@
           "lineCode": "M20-11",
           "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T10:38:00.000Z",
+          "scheduledTime": "2026-06-23T10:38:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1159,7 +1150,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-22T10:40:00.000Z",
+          "scheduledTime": "2026-06-23T10:40:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1168,7 +1159,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-22T11:05:00.000Z",
+          "scheduledTime": "2026-06-23T11:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1177,7 +1168,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-22T11:20:00.000Z",
+          "scheduledTime": "2026-06-23T11:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1186,7 +1177,7 @@
           "lineCode": "M20-10",
           "lineName": "Jaén - Torredelcampo, 2024",
           "destination": "Torredelcampo",
-          "scheduledTime": "2026-06-22T11:25:00.000Z",
+          "scheduledTime": "2026-06-23T11:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1195,7 +1186,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T11:28:00.000Z",
+          "scheduledTime": "2026-06-23T11:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1204,7 +1195,7 @@
           "lineCode": "M20-12",
           "lineName": "Jaén - Escañuela, 2024",
           "destination": "Escañuela",
-          "scheduledTime": "2026-06-22T11:55:00.000Z",
+          "scheduledTime": "2026-06-23T11:55:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1213,7 +1204,7 @@
           "lineCode": "M20-08",
           "lineName": "Jaén - Lopera, 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-22T12:20:00.000Z",
+          "scheduledTime": "2026-06-23T12:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1222,7 +1213,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-22T12:20:00.000Z",
+          "scheduledTime": "2026-06-23T12:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1231,7 +1222,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-22T12:25:00.000Z",
+          "scheduledTime": "2026-06-23T12:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1240,15 +1231,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T12:28:00.000Z",
+          "scheduledTime": "2026-06-23T12:28:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T12:30:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T12:30:00.000Z"
       }
     },
     {
@@ -1268,7 +1259,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T10:15:00.000Z",
+          "scheduledTime": "2026-06-23T10:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1277,7 +1268,7 @@
           "lineCode": "M20-11",
           "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T10:25:00.000Z",
+          "scheduledTime": "2026-06-23T10:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1286,7 +1277,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-22T10:33:00.000Z",
+          "scheduledTime": "2026-06-23T10:33:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1295,7 +1286,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-22T10:53:00.000Z",
+          "scheduledTime": "2026-06-23T10:53:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1304,7 +1295,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T11:15:00.000Z",
+          "scheduledTime": "2026-06-23T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1313,7 +1304,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-22T11:18:00.000Z",
+          "scheduledTime": "2026-06-23T11:18:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1322,7 +1313,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-22T11:33:00.000Z",
+          "scheduledTime": "2026-06-23T11:33:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1331,7 +1322,7 @@
           "lineCode": "M20-12",
           "lineName": "Jaén - Escañuela, 2024",
           "destination": "Escañuela",
-          "scheduledTime": "2026-06-22T12:08:00.000Z",
+          "scheduledTime": "2026-06-23T12:08:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1340,15 +1331,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T12:15:00.000Z",
+          "scheduledTime": "2026-06-23T12:15:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T12:30:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T12:30:00.000Z"
       }
     },
     {
@@ -1368,7 +1359,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T10:05:00.000Z",
+          "scheduledTime": "2026-06-23T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1377,7 +1368,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-22T10:10:00.000Z",
+          "scheduledTime": "2026-06-23T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1386,7 +1377,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-22T10:15:00.000Z",
+          "scheduledTime": "2026-06-23T10:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1395,7 +1386,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T10:45:00.000Z",
+          "scheduledTime": "2026-06-23T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1404,7 +1395,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-22T11:00:00.000Z",
+          "scheduledTime": "2026-06-23T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1413,7 +1404,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-22T11:25:00.000Z",
+          "scheduledTime": "2026-06-23T11:25:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1422,7 +1413,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T11:30:00.000Z",
+          "scheduledTime": "2026-06-23T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1431,15 +1422,15 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-22T11:55:00.000Z",
+          "scheduledTime": "2026-06-23T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T12:30:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T12:30:00.000Z"
       }
     },
     {
@@ -1459,7 +1450,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-22T10:45:00.000Z",
+          "scheduledTime": "2026-06-23T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1468,7 +1459,7 @@
           "lineCode": "M3-103",
           "lineName": "Úbeda - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-22T11:00:00.000Z",
+          "scheduledTime": "2026-06-23T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1477,7 +1468,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-22T11:25:00.000Z",
+          "scheduledTime": "2026-06-23T11:25:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1486,7 +1477,7 @@
           "lineCode": "M1-20",
           "lineName": "Pozo Alcón - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-22T12:00:00.000Z",
+          "scheduledTime": "2026-06-23T12:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1495,15 +1486,15 @@
           "lineCode": "M1-5",
           "lineName": "Quesada - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-22T12:00:00.000Z",
+          "scheduledTime": "2026-06-23T12:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T12:30:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T12:30:00.000Z"
       }
     },
     {
@@ -1519,9 +1510,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-23T02:39:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-24T02:39:00.000Z"
       }
     },
     {
@@ -1537,9 +1528,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-23T02:39:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-24T02:39:00.000Z"
       }
     },
     {
@@ -1555,9 +1546,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-23T02:39:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-24T02:39:00.000Z"
       }
     },
     {
@@ -1573,9 +1564,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-23T02:39:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-24T02:39:00.000Z"
       }
     },
     {
@@ -1591,9 +1582,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-23T02:39:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-24T02:39:00.000Z"
       }
     },
     {
@@ -1613,7 +1604,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-22T10:05:00.000Z",
+          "scheduledTime": "2026-06-23T10:05:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1622,7 +1613,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-22T10:41:00.000Z",
+          "scheduledTime": "2026-06-23T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1631,7 +1622,7 @@
           "lineCode": "M-310",
           "lineName": "Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-22T11:34:00.000Z",
+          "scheduledTime": "2026-06-23T11:34:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1640,7 +1631,7 @@
           "lineCode": "M-902",
           "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-22T11:36:00.000Z",
+          "scheduledTime": "2026-06-23T11:36:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1649,7 +1640,7 @@
           "lineCode": "M-306",
           "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-22T11:44:00.000Z",
+          "scheduledTime": "2026-06-23T11:44:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1658,7 +1649,7 @@
           "lineCode": "M-306",
           "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-22T12:06:00.000Z",
+          "scheduledTime": "2026-06-23T12:06:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1667,7 +1658,7 @@
           "lineCode": "M-316",
           "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
           "destination": "VILLABLANCA",
-          "scheduledTime": "2026-06-22T12:36:00.000Z",
+          "scheduledTime": "2026-06-23T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1676,7 +1667,7 @@
           "lineCode": "M-316",
           "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
           "destination": "VILLABLANCA",
-          "scheduledTime": "2026-06-22T12:36:00.000Z",
+          "scheduledTime": "2026-06-23T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1685,7 +1676,7 @@
           "lineCode": "M-902",
           "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-22T13:36:00.000Z",
+          "scheduledTime": "2026-06-23T13:36:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1694,7 +1685,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-22T13:41:00.000Z",
+          "scheduledTime": "2026-06-23T13:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1703,15 +1694,15 @@
           "lineCode": "M-902",
           "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-22T13:52:00.000Z",
+          "scheduledTime": "2026-06-23T13:52:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T14:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T14:00:00.000Z"
       }
     },
     {
@@ -1731,7 +1722,7 @@
           "lineCode": "M-314",
           "lineName": "Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-22T10:30:00.000Z",
+          "scheduledTime": "2026-06-23T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1740,7 +1731,7 @@
           "lineCode": "M-310",
           "lineName": "Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-22T11:14:00.000Z",
+          "scheduledTime": "2026-06-23T11:14:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1749,7 +1740,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-22T11:20:00.000Z",
+          "scheduledTime": "2026-06-23T11:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1758,7 +1749,7 @@
           "lineCode": "M-306",
           "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-22T11:20:00.000Z",
+          "scheduledTime": "2026-06-23T11:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1767,7 +1758,7 @@
           "lineCode": "M-314",
           "lineName": "Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-22T11:30:00.000Z",
+          "scheduledTime": "2026-06-23T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1776,7 +1767,7 @@
           "lineCode": "M-306",
           "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-22T12:29:00.000Z",
+          "scheduledTime": "2026-06-23T12:29:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1785,15 +1776,15 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-22T13:20:00.000Z",
+          "scheduledTime": "2026-06-23T13:20:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T14:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T14:00:00.000Z"
       }
     },
     {
@@ -1813,7 +1804,7 @@
           "lineCode": "M-906",
           "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
           "destination": "ROCIANA DEL CONDADO",
-          "scheduledTime": "2026-06-22T12:28:00.000Z",
+          "scheduledTime": "2026-06-23T12:28:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1822,7 +1813,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-06-22T12:33:00.000Z",
+          "scheduledTime": "2026-06-23T12:33:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1831,7 +1822,7 @@
           "lineCode": "M-405",
           "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-06-22T12:36:00.000Z",
+          "scheduledTime": "2026-06-23T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1840,7 +1831,7 @@
           "lineCode": "M-407",
           "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-22T13:17:00.000Z",
+          "scheduledTime": "2026-06-23T13:17:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1849,15 +1840,15 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-22T13:33:00.000Z",
+          "scheduledTime": "2026-06-23T13:33:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T14:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T14:00:00.000Z"
       }
     },
     {
@@ -1873,9 +1864,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T14:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T14:00:00.000Z"
       }
     },
     {
@@ -1891,9 +1882,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-22T06:50:58.085Z",
-        "startTime": "2026-06-22T10:00:00.000Z",
-        "endTime": "2026-06-22T14:00:00.000Z"
+        "requestedAt": "2026-06-23T06:26:23.794Z",
+        "startTime": "2026-06-23T10:00:00.000Z",
+        "endTime": "2026-06-23T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:48.817Z",
+    "generatedAt": "2026-06-23T06:26:16.932Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:48.817Z",
+    "generatedAt": "2026-06-23T06:26:16.932Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:48.817Z",
+    "generatedAt": "2026-06-23T06:26:16.932Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:48.817Z",
+    "generatedAt": "2026-06-23T06:26:16.932Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:48.817Z",
+    "generatedAt": "2026-06-23T06:26:16.932Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:48.817Z",
+    "generatedAt": "2026-06-23T06:26:16.932Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:48.817Z",
+    "generatedAt": "2026-06-23T06:26:16.932Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:48.817Z",
+    "generatedAt": "2026-06-23T06:26:16.932Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:48.817Z",
+    "generatedAt": "2026-06-23T06:26:16.932Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-22T06:50:48.817Z",
+    "generatedAt": "2026-06-23T06:26:16.932Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-06-23 06:27 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refreshed and regenerated catalog data across all consortiums with updated timestamps.
  * Removed two route entries from consortium-2's service catalog.
  * Updated stop service snapshot data with current scheduled times and request timestamps.
  * Refreshed stop directory information across all consortiums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->