### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,13 +1,109 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,
     "consortiumName": "Campo de Gibraltar",
-    "itemCount": 5
+    "itemCount": 15
   },
   "lines": [
+    {
+      "id": "4",
+      "code": "M-120",
+      "name": "Algeciras-La Línea",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Transportes Generales Comes"
+      ],
+      "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "7",
+      "code": "M-150",
+      "name": "Algeciras-Tarifa",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Transportes Generales Comes"
+      ],
+      "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "9",
+      "code": "M-161",
+      "name": "Barbate-Facinas-Algeciras",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Transportes Generales Comes"
+      ],
+      "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "19",
+      "code": "M-470",
+      "name": "Bus Playa",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Transportes Generales Comes"
+      ],
+      "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
     {
       "id": "12",
       "code": "M-240",
@@ -42,6 +138,54 @@
       "operators": [
         "AVANZA Movilidad Urbana",
         "S.L.",
+        "Transportes Generales Comes"
+      ],
+      "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "27",
+      "code": "M-260",
+      "name": "La Línea-Tahivilla",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Transportes Generales Comes"
+      ],
+      "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "14",
+      "code": "M-271",
+      "name": "La Línea-Tesorillo",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
         "Transportes Generales Comes"
       ],
       "hasNews": true,
@@ -110,6 +254,78 @@
       "inboundPath": []
     },
     {
+      "id": "5",
+      "code": "M-121",
+      "name": "Los Barrios-La Línea",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Transportes Generales Comes"
+      ],
+      "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "10",
+      "code": "M-170",
+      "name": "San Pablo-Jimena-Castellar-Algeciras",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Transportes Generales Comes"
+      ],
+      "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "28",
+      "code": "M-272",
+      "name": "San Pablo-Jimena-Castellar-Hospital-La Línea",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Transportes Generales Comes"
+      ],
+      "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
       "id": "6",
       "code": "M-130",
       "name": "San Roque-Algeciras",
@@ -118,6 +334,30 @@
       "operators": [
         "Empresa Esteban",
         "S.A."
+      ],
+      "hasNews": true,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "8",
+      "code": "M-160",
+      "name": "Tahivilla-Facinas-Tarifa-Algeciras",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Transportes Generales Comes"
       ],
       "hasNews": true,
       "concession": null,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:20.308Z",
+    "generatedAt": "2026-06-24T06:24:03.820Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:23.794Z",
+    "generatedAt": "2026-06-24T06:24:07.026Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -23,7 +23,7 @@
           "lineCode": "1320",
           "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-23T10:07:00.000Z",
+          "scheduledTime": "2026-06-24T10:07:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -32,15 +32,15 @@
           "lineCode": "1320",
           "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-23T10:37:00.000Z",
+          "scheduledTime": "2026-06-24T10:37:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -60,7 +60,7 @@
           "lineCode": "1666",
           "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-23T10:31:00.000Z",
+          "scheduledTime": "2026-06-24T10:31:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -69,7 +69,7 @@
           "lineCode": "1681",
           "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-23T10:42:00.000Z",
+          "scheduledTime": "2026-06-24T10:42:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -78,7 +78,7 @@
           "lineCode": "1020",
           "lineName": "M-102A Circular Aljarafe (sentido A)",
           "destination": "SANLUCAR LA MAYOR",
-          "scheduledTime": "2026-06-23T10:46:00.000Z",
+          "scheduledTime": "2026-06-24T10:46:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -87,15 +87,15 @@
           "lineCode": "1661",
           "lineName": "M-166 Sanlúcar la Mayor - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-23T10:48:00.000Z",
+          "scheduledTime": "2026-06-24T10:48:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -115,7 +115,7 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-23T10:02:00.000Z",
+          "scheduledTime": "2026-06-24T10:02:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -124,15 +124,15 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-23T10:32:00.000Z",
+          "scheduledTime": "2026-06-24T10:32:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -148,9 +148,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -170,7 +170,7 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-23T10:04:00.000Z",
+          "scheduledTime": "2026-06-24T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -179,7 +179,7 @@
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-06-23T10:04:00.000Z",
+          "scheduledTime": "2026-06-24T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -188,15 +188,15 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-23T10:34:00.000Z",
+          "scheduledTime": "2026-06-24T10:34:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -212,9 +212,9 @@
       "nucleus": "Penal",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -230,9 +230,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -252,7 +252,16 @@
           "lineCode": "M-967",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-23T10:05:00.000Z",
+          "scheduledTime": "2026-06-24T10:05:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "167",
+          "lineCode": "M-964",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
+          "destination": "Jerez",
+          "scheduledTime": "2026-06-24T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -261,15 +270,33 @@
           "lineCode": "M-967",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-23T10:28:00.000Z",
+          "scheduledTime": "2026-06-24T10:28:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "172",
+          "lineCode": "M-561",
+          "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
+          "destination": "Jerez",
+          "scheduledTime": "2026-06-24T10:45:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "167",
+          "lineCode": "M-964",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
+          "destination": "Chipiona",
+          "scheduledTime": "2026-06-24T10:50:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -289,7 +316,7 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-23T10:16:00.000Z",
+          "scheduledTime": "2026-06-24T10:16:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -298,15 +325,15 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Chiclana",
-          "scheduledTime": "2026-06-23T10:44:00.000Z",
+          "scheduledTime": "2026-06-24T10:44:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -326,7 +353,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-23T10:05:00.000Z",
+          "scheduledTime": "2026-06-24T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -335,7 +362,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-23T10:10:00.000Z",
+          "scheduledTime": "2026-06-24T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -344,7 +371,7 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-23T10:21:00.000Z",
+          "scheduledTime": "2026-06-24T10:21:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -353,7 +380,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-23T10:35:00.000Z",
+          "scheduledTime": "2026-06-24T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -362,7 +389,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-23T10:40:00.000Z",
+          "scheduledTime": "2026-06-24T10:40:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -371,7 +398,7 @@
           "lineCode": "M-031",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
           "destination": "Puerto Real",
-          "scheduledTime": "2026-06-23T10:51:00.000Z",
+          "scheduledTime": "2026-06-24T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -380,15 +407,15 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-23T11:00:00.000Z",
+          "scheduledTime": "2026-06-24T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -408,7 +435,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-23T10:21:00.000Z",
+          "scheduledTime": "2026-06-24T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -417,7 +444,7 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-06-23T10:28:00.000Z",
+          "scheduledTime": "2026-06-24T10:28:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -426,7 +453,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-23T10:51:00.000Z",
+          "scheduledTime": "2026-06-24T10:51:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -435,7 +462,7 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-06-23T11:08:00.000Z",
+          "scheduledTime": "2026-06-24T11:08:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -444,7 +471,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-23T11:21:00.000Z",
+          "scheduledTime": "2026-06-24T11:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -453,7 +480,7 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-06-23T11:48:00.000Z",
+          "scheduledTime": "2026-06-24T11:48:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -462,15 +489,15 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-23T11:51:00.000Z",
+          "scheduledTime": "2026-06-24T11:51:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T12:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T12:00:00.000Z"
       }
     },
     {
@@ -490,7 +517,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Granada",
-          "scheduledTime": "2026-06-23T10:39:00.000Z",
+          "scheduledTime": "2026-06-24T10:39:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -499,7 +526,7 @@
           "lineCode": "0318",
           "lineName": "Granada - Colomera",
           "destination": "Cerro Cauro",
-          "scheduledTime": "2026-06-23T10:41:00.000Z",
+          "scheduledTime": "2026-06-24T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -508,15 +535,15 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Parque del Cubillas",
-          "scheduledTime": "2026-06-23T11:30:00.000Z",
+          "scheduledTime": "2026-06-24T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T12:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T12:00:00.000Z"
       }
     },
     {
@@ -536,7 +563,7 @@
           "lineCode": "0241",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
           "destination": "Cijuela",
-          "scheduledTime": "2026-06-23T10:26:00.000Z",
+          "scheduledTime": "2026-06-24T10:26:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -545,7 +572,7 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-23T11:27:00.000Z",
+          "scheduledTime": "2026-06-24T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -554,15 +581,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-23T11:57:00.000Z",
+          "scheduledTime": "2026-06-24T11:57:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T12:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T12:00:00.000Z"
       }
     },
     {
@@ -582,15 +609,15 @@
           "lineCode": "0340",
           "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
           "destination": "Granada",
-          "scheduledTime": "2026-06-23T11:01:00.000Z",
+          "scheduledTime": "2026-06-24T11:01:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T12:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T12:00:00.000Z"
       }
     },
     {
@@ -610,7 +637,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-23T10:01:00.000Z",
+          "scheduledTime": "2026-06-24T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -619,7 +646,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-23T10:30:00.000Z",
+          "scheduledTime": "2026-06-24T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -628,7 +655,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-23T10:35:00.000Z",
+          "scheduledTime": "2026-06-24T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -637,7 +664,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-23T11:15:00.000Z",
+          "scheduledTime": "2026-06-24T11:15:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -646,7 +673,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-23T11:15:00.000Z",
+          "scheduledTime": "2026-06-24T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -655,7 +682,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-23T11:46:00.000Z",
+          "scheduledTime": "2026-06-24T11:46:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -664,15 +691,15 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-23T11:55:00.000Z",
+          "scheduledTime": "2026-06-24T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T12:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T12:00:00.000Z"
       }
     },
     {
@@ -692,15 +719,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-23T10:11:00.000Z",
+          "scheduledTime": "2026-06-24T10:11:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T10:15:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T10:15:00.000Z"
       }
     },
     {
@@ -720,15 +747,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-23T10:08:00.000Z",
+          "scheduledTime": "2026-06-24T10:08:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T10:15:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T10:15:00.000Z"
       }
     },
     {
@@ -744,9 +771,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T10:15:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T10:15:00.000Z"
       }
     },
     {
@@ -766,15 +793,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-23T10:05:00.000Z",
+          "scheduledTime": "2026-06-24T10:05:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T10:15:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T10:15:00.000Z"
       }
     },
     {
@@ -794,15 +821,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-23T10:02:00.000Z",
+          "scheduledTime": "2026-06-24T10:02:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T10:15:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T10:15:00.000Z"
       }
     },
     {
@@ -818,9 +845,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -834,11 +861,30 @@
       },
       "municipality": "Tarifa ",
       "nucleus": "Tarifa",
-      "services": [],
+      "services": [
+        {
+          "lineId": "9",
+          "lineCode": "M-161",
+          "lineName": "Barbate-Facinas-Algeciras",
+          "destination": "Algeciras",
+          "scheduledTime": "2026-06-24T10:10:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "7",
+          "lineCode": "M-150",
+          "lineName": "Algeciras-Tarifa",
+          "destination": "Algeciras",
+          "scheduledTime": "2026-06-24T10:45:00.000Z",
+          "direction": 2,
+          "stopType": 1
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -858,7 +904,7 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-23T10:30:00.000Z",
+          "scheduledTime": "2026-06-24T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -867,15 +913,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-23T10:30:00.000Z",
+          "scheduledTime": "2026-06-24T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -895,15 +941,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-23T10:03:00.000Z",
+          "scheduledTime": "2026-06-24T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -923,7 +969,7 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-23T10:45:00.000Z",
+          "scheduledTime": "2026-06-24T10:45:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -932,15 +978,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-06-23T11:00:00.000Z",
+          "scheduledTime": "2026-06-24T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -960,7 +1006,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ADRA",
-          "scheduledTime": "2026-06-23T10:36:00.000Z",
+          "scheduledTime": "2026-06-24T10:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -969,7 +1015,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-06-23T10:48:00.000Z",
+          "scheduledTime": "2026-06-24T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -978,15 +1024,15 @@
           "lineCode": "M-384",
           "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
           "destination": "ADRA",
-          "scheduledTime": "2026-06-23T10:51:00.000Z",
+          "scheduledTime": "2026-06-24T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -1002,9 +1048,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -1020,9 +1066,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -1038,9 +1084,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -1056,9 +1102,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T11:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T11:00:00.000Z"
       }
     },
     {
@@ -1074,9 +1120,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T12:30:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T12:30:00.000Z"
       }
     },
     {
@@ -1096,7 +1142,7 @@
           "lineCode": "M20-02",
           "lineName": "Jaén - Jamilena, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T10:13:00.000Z",
+          "scheduledTime": "2026-06-24T10:13:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1105,7 +1151,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-23T10:20:00.000Z",
+          "scheduledTime": "2026-06-24T10:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1114,7 +1160,7 @@
           "lineCode": "M20-10",
           "lineName": "Jaén - Torredelcampo, 2024",
           "destination": "Torredelcampo",
-          "scheduledTime": "2026-06-23T10:25:00.000Z",
+          "scheduledTime": "2026-06-24T10:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1123,7 +1169,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T10:28:00.000Z",
+          "scheduledTime": "2026-06-24T10:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1132,7 +1178,7 @@
           "lineCode": "M20-10",
           "lineName": "Jaén - Torredelcampo, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T10:33:00.000Z",
+          "scheduledTime": "2026-06-24T10:33:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1141,7 +1187,7 @@
           "lineCode": "M20-11",
           "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T10:38:00.000Z",
+          "scheduledTime": "2026-06-24T10:38:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1150,7 +1196,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-23T10:40:00.000Z",
+          "scheduledTime": "2026-06-24T10:40:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1159,7 +1205,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-23T11:05:00.000Z",
+          "scheduledTime": "2026-06-24T11:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1168,7 +1214,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-23T11:20:00.000Z",
+          "scheduledTime": "2026-06-24T11:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1177,7 +1223,7 @@
           "lineCode": "M20-10",
           "lineName": "Jaén - Torredelcampo, 2024",
           "destination": "Torredelcampo",
-          "scheduledTime": "2026-06-23T11:25:00.000Z",
+          "scheduledTime": "2026-06-24T11:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1186,7 +1232,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T11:28:00.000Z",
+          "scheduledTime": "2026-06-24T11:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1195,7 +1241,7 @@
           "lineCode": "M20-12",
           "lineName": "Jaén - Escañuela, 2024",
           "destination": "Escañuela",
-          "scheduledTime": "2026-06-23T11:55:00.000Z",
+          "scheduledTime": "2026-06-24T11:55:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1204,7 +1250,7 @@
           "lineCode": "M20-08",
           "lineName": "Jaén - Lopera, 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-23T12:20:00.000Z",
+          "scheduledTime": "2026-06-24T12:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1213,7 +1259,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-23T12:20:00.000Z",
+          "scheduledTime": "2026-06-24T12:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1222,7 +1268,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-23T12:25:00.000Z",
+          "scheduledTime": "2026-06-24T12:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1231,15 +1277,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T12:28:00.000Z",
+          "scheduledTime": "2026-06-24T12:28:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T12:30:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T12:30:00.000Z"
       }
     },
     {
@@ -1259,7 +1305,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T10:15:00.000Z",
+          "scheduledTime": "2026-06-24T10:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1268,7 +1314,7 @@
           "lineCode": "M20-11",
           "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T10:25:00.000Z",
+          "scheduledTime": "2026-06-24T10:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1277,7 +1323,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-23T10:33:00.000Z",
+          "scheduledTime": "2026-06-24T10:33:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1286,7 +1332,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-23T10:53:00.000Z",
+          "scheduledTime": "2026-06-24T10:53:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1295,7 +1341,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T11:15:00.000Z",
+          "scheduledTime": "2026-06-24T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1304,7 +1350,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-23T11:18:00.000Z",
+          "scheduledTime": "2026-06-24T11:18:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1313,7 +1359,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-23T11:33:00.000Z",
+          "scheduledTime": "2026-06-24T11:33:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1322,7 +1368,7 @@
           "lineCode": "M20-12",
           "lineName": "Jaén - Escañuela, 2024",
           "destination": "Escañuela",
-          "scheduledTime": "2026-06-23T12:08:00.000Z",
+          "scheduledTime": "2026-06-24T12:08:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1331,15 +1377,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T12:15:00.000Z",
+          "scheduledTime": "2026-06-24T12:15:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T12:30:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T12:30:00.000Z"
       }
     },
     {
@@ -1359,7 +1405,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T10:05:00.000Z",
+          "scheduledTime": "2026-06-24T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1368,7 +1414,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-23T10:10:00.000Z",
+          "scheduledTime": "2026-06-24T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1377,7 +1423,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-23T10:15:00.000Z",
+          "scheduledTime": "2026-06-24T10:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1386,7 +1432,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T10:45:00.000Z",
+          "scheduledTime": "2026-06-24T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1395,7 +1441,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-23T11:00:00.000Z",
+          "scheduledTime": "2026-06-24T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1404,7 +1450,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-23T11:25:00.000Z",
+          "scheduledTime": "2026-06-24T11:25:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1413,7 +1459,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T11:30:00.000Z",
+          "scheduledTime": "2026-06-24T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1422,15 +1468,15 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-23T11:55:00.000Z",
+          "scheduledTime": "2026-06-24T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T12:30:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T12:30:00.000Z"
       }
     },
     {
@@ -1450,7 +1496,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-23T10:45:00.000Z",
+          "scheduledTime": "2026-06-24T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1459,7 +1505,7 @@
           "lineCode": "M3-103",
           "lineName": "Úbeda - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-23T11:00:00.000Z",
+          "scheduledTime": "2026-06-24T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1468,7 +1514,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-23T11:25:00.000Z",
+          "scheduledTime": "2026-06-24T11:25:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1477,7 +1523,7 @@
           "lineCode": "M1-20",
           "lineName": "Pozo Alcón - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-23T12:00:00.000Z",
+          "scheduledTime": "2026-06-24T12:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1486,15 +1532,15 @@
           "lineCode": "M1-5",
           "lineName": "Quesada - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-23T12:00:00.000Z",
+          "scheduledTime": "2026-06-24T12:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T12:30:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T12:30:00.000Z"
       }
     },
     {
@@ -1510,9 +1556,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-24T02:39:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-25T02:39:00.000Z"
       }
     },
     {
@@ -1528,9 +1574,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-24T02:39:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-25T02:39:00.000Z"
       }
     },
     {
@@ -1546,9 +1592,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-24T02:39:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-25T02:39:00.000Z"
       }
     },
     {
@@ -1564,9 +1610,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-24T02:39:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-25T02:39:00.000Z"
       }
     },
     {
@@ -1582,9 +1628,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-24T02:39:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-25T02:39:00.000Z"
       }
     },
     {
@@ -1604,7 +1650,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-23T10:05:00.000Z",
+          "scheduledTime": "2026-06-24T10:05:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1613,7 +1659,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-23T10:41:00.000Z",
+          "scheduledTime": "2026-06-24T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1622,7 +1668,7 @@
           "lineCode": "M-310",
           "lineName": "Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-23T11:34:00.000Z",
+          "scheduledTime": "2026-06-24T11:34:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1631,7 +1677,7 @@
           "lineCode": "M-902",
           "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-23T11:36:00.000Z",
+          "scheduledTime": "2026-06-24T11:36:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1640,7 +1686,7 @@
           "lineCode": "M-306",
           "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-23T11:44:00.000Z",
+          "scheduledTime": "2026-06-24T11:44:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1649,7 +1695,7 @@
           "lineCode": "M-306",
           "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-23T12:06:00.000Z",
+          "scheduledTime": "2026-06-24T12:06:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1658,7 +1704,7 @@
           "lineCode": "M-316",
           "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
           "destination": "VILLABLANCA",
-          "scheduledTime": "2026-06-23T12:36:00.000Z",
+          "scheduledTime": "2026-06-24T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1667,7 +1713,7 @@
           "lineCode": "M-316",
           "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
           "destination": "VILLABLANCA",
-          "scheduledTime": "2026-06-23T12:36:00.000Z",
+          "scheduledTime": "2026-06-24T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1676,7 +1722,7 @@
           "lineCode": "M-902",
           "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-23T13:36:00.000Z",
+          "scheduledTime": "2026-06-24T13:36:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1685,7 +1731,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-23T13:41:00.000Z",
+          "scheduledTime": "2026-06-24T13:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1694,15 +1740,15 @@
           "lineCode": "M-902",
           "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-23T13:52:00.000Z",
+          "scheduledTime": "2026-06-24T13:52:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T14:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T14:00:00.000Z"
       }
     },
     {
@@ -1722,7 +1768,7 @@
           "lineCode": "M-314",
           "lineName": "Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-23T10:30:00.000Z",
+          "scheduledTime": "2026-06-24T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1731,7 +1777,7 @@
           "lineCode": "M-310",
           "lineName": "Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-23T11:14:00.000Z",
+          "scheduledTime": "2026-06-24T11:14:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1740,7 +1786,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-23T11:20:00.000Z",
+          "scheduledTime": "2026-06-24T11:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1749,7 +1795,7 @@
           "lineCode": "M-306",
           "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-23T11:20:00.000Z",
+          "scheduledTime": "2026-06-24T11:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1758,7 +1804,7 @@
           "lineCode": "M-314",
           "lineName": "Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-23T11:30:00.000Z",
+          "scheduledTime": "2026-06-24T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1767,7 +1813,7 @@
           "lineCode": "M-306",
           "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-23T12:29:00.000Z",
+          "scheduledTime": "2026-06-24T12:29:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1776,15 +1822,15 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-23T13:20:00.000Z",
+          "scheduledTime": "2026-06-24T13:20:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T14:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T14:00:00.000Z"
       }
     },
     {
@@ -1804,7 +1850,7 @@
           "lineCode": "M-906",
           "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
           "destination": "ROCIANA DEL CONDADO",
-          "scheduledTime": "2026-06-23T12:28:00.000Z",
+          "scheduledTime": "2026-06-24T12:28:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1813,7 +1859,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-06-23T12:33:00.000Z",
+          "scheduledTime": "2026-06-24T12:33:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1822,7 +1868,7 @@
           "lineCode": "M-405",
           "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-06-23T12:36:00.000Z",
+          "scheduledTime": "2026-06-24T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1831,7 +1877,7 @@
           "lineCode": "M-407",
           "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-23T13:17:00.000Z",
+          "scheduledTime": "2026-06-24T13:17:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1840,15 +1886,15 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-23T13:33:00.000Z",
+          "scheduledTime": "2026-06-24T13:33:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T14:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T14:00:00.000Z"
       }
     },
     {
@@ -1864,9 +1910,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T14:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T14:00:00.000Z"
       }
     },
     {
@@ -1882,9 +1928,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-23T06:26:23.794Z",
-        "startTime": "2026-06-23T10:00:00.000Z",
-        "endTime": "2026-06-23T14:00:00.000Z"
+        "requestedAt": "2026-06-24T06:24:07.026Z",
+        "startTime": "2026-06-24T10:00:00.000Z",
+        "endTime": "2026-06-24T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:16.932Z",
+    "generatedAt": "2026-06-24T06:24:00.732Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:16.932Z",
+    "generatedAt": "2026-06-24T06:24:00.732Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:16.932Z",
+    "generatedAt": "2026-06-24T06:24:00.732Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:16.932Z",
+    "generatedAt": "2026-06-24T06:24:00.732Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:16.932Z",
+    "generatedAt": "2026-06-24T06:24:00.732Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:16.932Z",
+    "generatedAt": "2026-06-24T06:24:00.732Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:16.932Z",
+    "generatedAt": "2026-06-24T06:24:00.732Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:16.932Z",
+    "generatedAt": "2026-06-24T06:24:00.732Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:16.932Z",
+    "generatedAt": "2026-06-24T06:24:00.732Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-23T06:26:16.932Z",
+    "generatedAt": "2026-06-24T06:24:00.732Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-06-24 06:24 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refreshed catalog and stop-directory data timestamps across multiple areas.
  * Updated the latest stop-services snapshot with newer service times and request windows.
  * Added previously missing service entries for one stop.
  * Expanded one consortium’s line dataset with additional route entries and a higher item count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->