### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,
@@ -1506,7 +1506,7 @@
     {
       "id": "322",
       "code": "M-362",
-      "name": "Málaga-Nerja",
+      "name": "Málaga-Nerja (No se permite el viaje entre Vélez-Málaga y Torre del Mar en ambos sentidos)",
       "mode": "Autobús",
       "modeId": "1",
       "operators": [
@@ -1730,7 +1730,7 @@
     {
       "id": "321",
       "code": "M-260",
-      "name": "Málaga-Torre Benagalbón-Torre del Mar-Vélez Málaga",
+      "name": "Málaga-Torre Benagalbón-Torre del Mar-Vélez Málaga (prohibido entre Vélez-Málaga y Torre del M\u0000\u0000a",
       "mode": "Autobús",
       "modeId": "1",
       "operators": [

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,
     "consortiumName": "Costa de Huelva",
-    "itemCount": 40
+    "itemCount": 53
   },
   "lines": [
     {
@@ -84,6 +84,78 @@
       "id": "6",
       "code": "M-312",
       "name": "Ayamonte-Punta Del Moral (Circular)",
+      "mode": "AUTOBUS",
+      "modeId": "2",
+      "operators": [
+        "DAMAS SA"
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "81",
+      "code": "M-414B",
+      "name": "Beas - Mazagon",
+      "mode": "AUTOBUS",
+      "modeId": "2",
+      "operators": [
+        "DAMAS SA"
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "58",
+      "code": "M-415",
+      "name": "Bonares-Mazagon",
+      "mode": "AUTOBUS",
+      "modeId": "2",
+      "operators": [
+        "DAMAS SA"
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "37",
+      "code": "M-311",
+      "name": "Cartaya-Punta Umbria",
       "mode": "AUTOBUS",
       "modeId": "2",
       "operators": [
@@ -201,6 +273,30 @@
       "inboundPath": []
     },
     {
+      "id": "44",
+      "code": "M-401",
+      "name": "Huelva-Base Del Espigon Juan Carlos I",
+      "mode": "AUTOBUS",
+      "modeId": "2",
+      "operators": [
+        "DAMAS SA"
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
       "id": "32",
       "code": "M-300",
       "name": "Huelva-Bellavista-Aljaraque",
@@ -276,6 +372,30 @@
       "id": "50",
       "code": "M-407",
       "name": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
+      "mode": "AUTOBUS",
+      "modeId": "2",
+      "operators": [
+        "DAMAS SA"
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "13",
+      "code": "M-303",
+      "name": "Huelva-Corrales-Ayamonte",
       "mode": "AUTOBUS",
       "modeId": "2",
       "operators": [
@@ -513,6 +633,54 @@
       "inboundPath": []
     },
     {
+      "id": "53",
+      "code": "M-410",
+      "name": "Huelva-Mazagon-Torre Higuera-Almonte",
+      "mode": "AUTOBUS",
+      "modeId": "2",
+      "operators": [
+        "DAMAS SA"
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "56",
+      "code": "M-413",
+      "name": "Huelva-Moguer-Mazagon",
+      "mode": "AUTOBUS",
+      "modeId": "2",
+      "operators": [
+        "DAMAS SA"
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
       "id": "24",
       "code": "M-205",
       "name": "Huelva-Nerva",
@@ -564,6 +732,30 @@
       "id": "46",
       "code": "M-403",
       "name": "Huelva-Palos de la Frontera-Moguer",
+      "mode": "AUTOBUS",
+      "modeId": "2",
+      "operators": [
+        "DAMAS SA"
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "52",
+      "code": "M-409",
+      "name": "Huelva-Palos De La Frontera-Torre Higuera",
       "mode": "AUTOBUS",
       "modeId": "2",
       "operators": [
@@ -897,6 +1089,78 @@
       "inboundPath": []
     },
     {
+      "id": "38",
+      "code": "M-313",
+      "name": "Lepe-La Antilla",
+      "mode": "AUTOBUS",
+      "modeId": "2",
+      "operators": [
+        "DAMAS SA"
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "60",
+      "code": "M-417",
+      "name": "Paterna-Torre Higuera",
+      "mode": "AUTOBUS",
+      "modeId": "2",
+      "operators": [
+        "DAMAS SA"
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "57",
+      "code": "M-414",
+      "name": "San Juan Del Puerto-Moguer-Palos-Mazagon",
+      "mode": "AUTOBUS",
+      "modeId": "2",
+      "operators": [
+        "DAMAS SA"
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
       "id": "70",
       "code": "M-906",
       "name": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
@@ -924,6 +1188,54 @@
       "id": "75",
       "code": "M-911",
       "name": "Sevilla-Hinojos-Almonte-Caño Guerrero",
+      "mode": "AUTOBUS",
+      "modeId": "2",
+      "operators": [
+        "DAMAS SA"
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "69",
+      "code": "M-905",
+      "name": "Sevilla-Huelva-La Antilla-Isla Cristina",
+      "mode": "AUTOBUS",
+      "modeId": "2",
+      "operators": [
+        "DAMAS SA"
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "74",
+      "code": "M-910",
+      "name": "Sevilla-Mazagon",
       "mode": "AUTOBUS",
       "modeId": "2",
       "operators": [

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:01.757Z",
+    "generatedAt": "2026-06-27T06:14:31.513Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:27:05.347Z",
+    "generatedAt": "2026-06-27T06:14:37.107Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -17,30 +17,11 @@
       },
       "municipality": "DOS HERMANAS",
       "nucleus": "FUENTE DEL REY (Dos Hermanas) zonaC",
-      "services": [
-        {
-          "lineId": "242",
-          "lineCode": "1320",
-          "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-26T10:07:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "242",
-          "lineCode": "1320",
-          "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-26T10:37:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -60,7 +41,7 @@
           "lineCode": "1666",
           "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-26T10:31:00.000Z",
+          "scheduledTime": "2026-06-27T10:31:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -69,33 +50,15 @@
           "lineCode": "1681",
           "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-26T10:42:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "290",
-          "lineCode": "1020",
-          "lineName": "M-102A Circular Aljarafe (sentido A)",
-          "destination": "SANLUCAR LA MAYOR",
-          "scheduledTime": "2026-06-26T10:46:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "279",
-          "lineCode": "1661",
-          "lineName": "M-166 Sanlúcar la Mayor - Sevilla",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-26T10:48:00.000Z",
+          "scheduledTime": "2026-06-27T10:57:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -115,7 +78,7 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-26T10:02:00.000Z",
+          "scheduledTime": "2026-06-27T10:17:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -124,15 +87,15 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-26T10:32:00.000Z",
+          "scheduledTime": "2026-06-27T10:47:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -148,9 +111,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -170,7 +133,7 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-26T10:04:00.000Z",
+          "scheduledTime": "2026-06-27T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -179,7 +142,7 @@
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-06-26T10:04:00.000Z",
+          "scheduledTime": "2026-06-27T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -188,15 +151,15 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-26T10:34:00.000Z",
+          "scheduledTime": "2026-06-27T10:34:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -216,15 +179,24 @@
           "lineCode": "M-560",
           "lineName": "Rota-Jerez De La Frontera",
           "destination": "Rota",
-          "scheduledTime": "2026-06-26T10:00:00.000Z",
+          "scheduledTime": "2026-06-27T10:30:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "32",
+          "lineCode": "M-560",
+          "lineName": "Rota-Jerez De La Frontera",
+          "destination": "Jerez",
+          "scheduledTime": "2026-06-27T11:00:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -240,9 +212,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -258,11 +230,11 @@
       "nucleus": "Sanlúcar de Barrameda",
       "services": [
         {
-          "lineId": "225",
-          "lineCode": "M-967",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
+          "lineId": "163",
+          "lineCode": "M-960",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-26T10:05:00.000Z",
+          "scheduledTime": "2026-06-27T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -271,16 +243,25 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Jerez",
-          "scheduledTime": "2026-06-26T10:05:00.000Z",
+          "scheduledTime": "2026-06-27T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "225",
-          "lineCode": "M-967",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
+          "lineId": "230",
+          "lineCode": "M-965",
+          "lineName": "Chipiona-Sanlúcar De Barrameda (Sevilla/Utrera)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-26T10:28:00.000Z",
+          "scheduledTime": "2026-06-27T10:11:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "231",
+          "lineCode": "M-974",
+          "lineName": "Costa Ballena-Chipiona-Sanlúcar De Barrameda (Sevilla)",
+          "destination": "Costa Ballena (Rota)",
+          "scheduledTime": "2026-06-27T10:12:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -289,24 +270,15 @@
           "lineCode": "M-561",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
           "destination": "Jerez",
-          "scheduledTime": "2026-06-26T10:45:00.000Z",
+          "scheduledTime": "2026-06-27T10:45:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "167",
-          "lineCode": "M-964",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
-          "destination": "Chipiona",
-          "scheduledTime": "2026-06-26T10:50:00.000Z",
-          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -320,30 +292,11 @@
       },
       "municipality": "Chiclana",
       "nucleus": "Chiclana",
-      "services": [
-        {
-          "lineId": "26",
-          "lineCode": "M-230",
-          "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
-          "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-26T10:16:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "26",
-          "lineCode": "M-230",
-          "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
-          "destination": "Chiclana",
-          "scheduledTime": "2026-06-26T10:44:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -362,17 +315,8 @@
           "lineId": "6",
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-26T10:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-26T10:10:00.000Z",
+          "scheduledTime": "2026-06-27T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -381,51 +325,15 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-26T10:21:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-26T10:35:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Cádiz",
-          "scheduledTime": "2026-06-26T10:40:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "9",
-          "lineCode": "M-031",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
-          "destination": "Puerto Real",
-          "scheduledTime": "2026-06-26T10:51:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Cádiz",
-          "scheduledTime": "2026-06-26T11:00:00.000Z",
+          "scheduledTime": "2026-06-27T10:21:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -445,69 +353,24 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-26T10:21:00.000Z",
+          "scheduledTime": "2026-06-27T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
         {
-          "lineId": "1077",
-          "lineCode": "0124",
-          "lineName": "Granada - Atarfe",
-          "destination": "Atarfe",
-          "scheduledTime": "2026-06-26T10:28:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-26T10:51:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "1077",
-          "lineCode": "0124",
-          "lineName": "Granada - Atarfe",
-          "destination": "Atarfe",
-          "scheduledTime": "2026-06-26T11:08:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-26T11:21:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "1077",
-          "lineCode": "0124",
-          "lineName": "Granada - Atarfe",
-          "destination": "Atarfe",
-          "scheduledTime": "2026-06-26T11:48:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-26T11:51:00.000Z",
+          "lineId": "992",
+          "lineCode": "0226",
+          "lineName": "Granada - P.Puente - Zujaira",
+          "destination": "Zujaira",
+          "scheduledTime": "2026-06-27T11:49:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T12:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T12:00:00.000Z"
       }
     },
     {
@@ -526,17 +389,8 @@
           "lineId": "1032",
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
-          "destination": "Granada",
-          "scheduledTime": "2026-06-26T10:39:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "710",
-          "lineCode": "0318",
-          "lineName": "Granada - Colomera",
-          "destination": "Cerro Cauro",
-          "scheduledTime": "2026-06-26T10:41:00.000Z",
+          "destination": "Centro Penitenciario de Albolote",
+          "scheduledTime": "2026-06-27T10:15:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -544,16 +398,25 @@
           "lineId": "1032",
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
-          "destination": "Parque del Cubillas",
-          "scheduledTime": "2026-06-26T11:30:00.000Z",
+          "destination": "Granada",
+          "scheduledTime": "2026-06-27T11:09:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "1032",
+          "lineCode": "0117",
+          "lineName": "Granada - P.Cubillas",
+          "destination": "Centro Penitenciario de Albolote",
+          "scheduledTime": "2026-06-27T11:45:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T12:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T12:00:00.000Z"
       }
     },
     {
@@ -569,11 +432,11 @@
       "nucleus": "Chauchina",
       "services": [
         {
-          "lineId": "868",
-          "lineCode": "0241",
-          "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
-          "destination": "Cijuela",
-          "scheduledTime": "2026-06-26T10:26:00.000Z",
+          "lineId": "1119",
+          "lineCode": "0242",
+          "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
+          "destination": "Láchar",
+          "scheduledTime": "2026-06-27T10:27:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -582,24 +445,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-26T11:27:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1119",
-          "lineCode": "0242",
-          "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
-          "destination": "Láchar",
-          "scheduledTime": "2026-06-26T11:57:00.000Z",
+          "scheduledTime": "2026-06-27T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T12:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T12:00:00.000Z"
       }
     },
     {
@@ -613,21 +467,11 @@
       },
       "municipality": "Cijuela",
       "nucleus": "Cijuela",
-      "services": [
-        {
-          "lineId": "877",
-          "lineCode": "0340",
-          "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
-          "destination": "Granada",
-          "scheduledTime": "2026-06-26T11:01:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T12:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T12:00:00.000Z"
       }
     },
     {
@@ -643,47 +487,11 @@
       "nucleus": "Ambroz",
       "services": [
         {
-          "lineId": "1113",
-          "lineCode": "0150",
-          "lineName": "Granada - Cúllar V. - V. del Genil",
-          "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-26T10:01:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
           "lineId": "1042",
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-26T10:30:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "1042",
-          "lineCode": "0154",
-          "lineName": "Granada-V. del Genil (Directo)",
-          "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-26T10:35:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1042",
-          "lineCode": "0154",
-          "lineName": "Granada-V. del Genil (Directo)",
-          "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-26T11:15:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1042",
-          "lineCode": "0154",
-          "lineName": "Granada-V. del Genil (Directo)",
-          "destination": "Granada",
-          "scheduledTime": "2026-06-26T11:15:00.000Z",
+          "scheduledTime": "2026-06-27T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -692,7 +500,16 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-26T11:46:00.000Z",
+          "scheduledTime": "2026-06-27T10:01:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "1042",
+          "lineCode": "0154",
+          "lineName": "Granada-V. del Genil (Directo)",
+          "destination": "El Ventorrillo",
+          "scheduledTime": "2026-06-27T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -701,15 +518,24 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-26T11:55:00.000Z",
+          "scheduledTime": "2026-06-27T11:15:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "1113",
+          "lineCode": "0150",
+          "lineName": "Granada - Cúllar V. - V. del Genil",
+          "destination": "El Ventorrillo",
+          "scheduledTime": "2026-06-27T11:31:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T12:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T12:00:00.000Z"
       }
     },
     {
@@ -723,21 +549,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-06-26T10:11:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T10:15:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T10:15:00.000Z"
       }
     },
     {
@@ -751,21 +567,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-06-26T10:08:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T10:15:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T10:15:00.000Z"
       }
     },
     {
@@ -781,9 +587,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T10:15:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T10:15:00.000Z"
       }
     },
     {
@@ -797,21 +603,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-06-26T10:05:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T10:15:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T10:15:00.000Z"
       }
     },
     {
@@ -825,21 +621,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-06-26T10:02:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T10:15:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T10:15:00.000Z"
       }
     },
     {
@@ -855,9 +641,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -877,24 +663,15 @@
           "lineCode": "M-161",
           "lineName": "Barbate-Facinas-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-26T10:10:00.000Z",
+          "scheduledTime": "2026-06-27T10:10:00.000Z",
           "direction": 1,
           "stopType": 0
-        },
-        {
-          "lineId": "7",
-          "lineCode": "M-150",
-          "lineName": "Algeciras-Tarifa",
-          "destination": "Algeciras",
-          "scheduledTime": "2026-06-26T10:45:00.000Z",
-          "direction": 2,
-          "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -914,7 +691,7 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-26T10:30:00.000Z",
+          "scheduledTime": "2026-06-27T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -923,15 +700,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-26T10:30:00.000Z",
+          "scheduledTime": "2026-06-27T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -951,15 +728,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-26T10:03:00.000Z",
+          "scheduledTime": "2026-06-27T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -979,8 +756,17 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-26T10:45:00.000Z",
+          "scheduledTime": "2026-06-27T10:45:00.000Z",
           "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "11",
+          "lineCode": "M-230",
+          "lineName": "La Línea-San Roque",
+          "destination": "La Línea de la Concepción",
+          "scheduledTime": "2026-06-27T10:45:00.000Z",
+          "direction": 2,
           "stopType": 1
         },
         {
@@ -988,15 +774,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-06-26T11:00:00.000Z",
+          "scheduledTime": "2026-06-27T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -1015,34 +801,16 @@
           "lineId": "40",
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
-          "destination": "ADRA",
-          "scheduledTime": "2026-06-26T10:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "40",
-          "lineCode": "M-380",
-          "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-06-26T10:48:00.000Z",
+          "scheduledTime": "2026-06-27T10:33:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "48",
-          "lineCode": "M-384",
-          "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
-          "destination": "ADRA",
-          "scheduledTime": "2026-06-26T10:51:00.000Z",
-          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -1058,9 +826,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -1076,9 +844,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -1094,9 +862,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -1112,9 +880,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T11:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T11:00:00.000Z"
       }
     },
     {
@@ -1130,9 +898,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T12:30:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T12:30:00.000Z"
       }
     },
     {
@@ -1148,11 +916,11 @@
       "nucleus": "Torredelcampo",
       "services": [
         {
-          "lineId": "279",
-          "lineCode": "M20-02",
-          "lineName": "Jaén - Jamilena, 2024",
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-26T10:13:00.000Z",
+          "scheduledTime": "2026-06-27T10:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1161,43 +929,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-26T10:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "286",
-          "lineCode": "M20-10",
-          "lineName": "Jaén - Torredelcampo, 2024",
-          "destination": "Torredelcampo",
-          "scheduledTime": "2026-06-26T10:25:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-26T10:28:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "286",
-          "lineCode": "M20-10",
-          "lineName": "Jaén - Torredelcampo, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-26T10:33:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-26T10:38:00.000Z",
+          "scheduledTime": "2026-06-27T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1206,70 +938,25 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-26T10:40:00.000Z",
+          "scheduledTime": "2026-06-27T11:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-26T11:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-26T11:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "286",
-          "lineCode": "M20-10",
-          "lineName": "Jaén - Torredelcampo, 2024",
-          "destination": "Torredelcampo",
-          "scheduledTime": "2026-06-26T11:25:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-26T11:28:00.000Z",
+          "lineId": "287",
+          "lineCode": "M20-11",
+          "lineName": "Fuensanta de Martos - Jaén, 2024",
+          "destination": "Fuensanta de Martos",
+          "scheduledTime": "2026-06-27T11:25:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "288",
-          "lineCode": "M20-12",
-          "lineName": "Jaén - Escañuela, 2024",
-          "destination": "Escañuela",
-          "scheduledTime": "2026-06-26T11:55:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "285",
-          "lineCode": "M20-08",
-          "lineName": "Jaén - Lopera, 2024",
-          "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-26T12:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-26T12:20:00.000Z",
+          "lineId": "279",
+          "lineCode": "M20-02",
+          "lineName": "Jaén - Jamilena, 2024",
+          "destination": "Jamilena",
+          "scheduledTime": "2026-06-27T11:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1278,7 +965,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-26T12:25:00.000Z",
+          "scheduledTime": "2026-06-27T11:55:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1287,15 +974,24 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-26T12:28:00.000Z",
+          "scheduledTime": "2026-06-27T12:08:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "280",
+          "lineCode": "M20-03",
+          "lineName": "Jaén - Villardompardo, 2024",
+          "destination": "Villardompardo",
+          "scheduledTime": "2026-06-27T12:25:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T12:30:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T12:30:00.000Z"
       }
     },
     {
@@ -1315,17 +1011,8 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-26T10:15:00.000Z",
+          "scheduledTime": "2026-06-27T10:15:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-26T10:25:00.000Z",
-          "direction": 1,
           "stopType": 0
         },
         {
@@ -1333,7 +1020,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-26T10:33:00.000Z",
+          "scheduledTime": "2026-06-27T10:48:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1342,16 +1029,16 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-26T10:53:00.000Z",
+          "scheduledTime": "2026-06-27T11:13:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-26T11:15:00.000Z",
+          "lineId": "287",
+          "lineCode": "M20-11",
+          "lineName": "Fuensanta de Martos - Jaén, 2024",
+          "destination": "Fuensanta de Martos",
+          "scheduledTime": "2026-06-27T11:38:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1359,43 +1046,25 @@
           "lineId": "278",
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-26T11:18:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-26T11:33:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "288",
-          "lineCode": "M20-12",
-          "lineName": "Jaén - Escañuela, 2024",
-          "destination": "Escañuela",
-          "scheduledTime": "2026-06-26T12:08:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-26T12:15:00.000Z",
+          "scheduledTime": "2026-06-27T11:55:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "281",
+          "lineCode": "M20-04",
+          "lineName": "Jaén - Alcaudete, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-06-27T12:08:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T12:30:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T12:30:00.000Z"
       }
     },
     {
@@ -1411,82 +1080,37 @@
       "nucleus": "Mengíbar",
       "services": [
         {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-26T10:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-06-26T10:10:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-06-26T10:15:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
           "lineId": "203",
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-26T10:45:00.000Z",
+          "scheduledTime": "2026-06-27T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-06-26T11:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-06-26T11:25:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-26T11:30:00.000Z",
+          "lineId": "276",
+          "lineCode": "M15-7",
+          "lineName": "Jaén - Andújar - Marmolejo",
+          "destination": "Andújar",
+          "scheduledTime": "2026-06-27T10:55:00.000Z",
           "direction": 1,
-          "stopType": 0
+          "stopType": 1
         },
         {
           "lineId": "203",
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-26T11:55:00.000Z",
+          "scheduledTime": "2026-06-27T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T12:30:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T12:30:00.000Z"
       }
     },
     {
@@ -1505,35 +1129,8 @@
           "lineId": "17",
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-26T10:45:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "35",
-          "lineCode": "M3-103",
-          "lineName": "Úbeda - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-26T11:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-06-26T11:25:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "21",
-          "lineCode": "M1-20",
-          "lineName": "Pozo Alcón - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-06-26T12:00:00.000Z",
+          "scheduledTime": "2026-06-27T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1542,15 +1139,24 @@
           "lineCode": "M1-5",
           "lineName": "Quesada - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-26T12:00:00.000Z",
+          "scheduledTime": "2026-06-27T12:00:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "22",
+          "lineCode": "M1-21",
+          "lineName": "Torres - Jaén",
+          "destination": "Torres",
+          "scheduledTime": "2026-06-27T12:25:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T12:30:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T12:30:00.000Z"
       }
     },
     {
@@ -1566,9 +1172,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-27T02:39:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-28T02:39:00.000Z"
       }
     },
     {
@@ -1584,9 +1190,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-27T02:39:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-28T02:39:00.000Z"
       }
     },
     {
@@ -1602,9 +1208,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-27T02:39:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-28T02:39:00.000Z"
       }
     },
     {
@@ -1620,9 +1226,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-27T02:39:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-28T02:39:00.000Z"
       }
     },
     {
@@ -1638,9 +1244,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-27T02:39:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-28T02:39:00.000Z"
       }
     },
     {
@@ -1656,109 +1262,46 @@
       "nucleus": "LEPE",
       "services": [
         {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-26T10:05:00.000Z",
+          "scheduledTime": "2026-06-27T10:03:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-26T10:41:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "5",
-          "lineCode": "M-310",
-          "lineName": "Huelva-Isla Cristina-Ayamonte",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-26T11:34:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "66",
-          "lineCode": "M-902",
-          "lineName": "Ayamonte-Huelva-Sevilla",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-26T11:36:00.000Z",
-          "direction": 2,
+          "scheduledTime": "2026-06-27T11:22:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "3",
-          "lineCode": "M-306",
-          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-26T11:44:00.000Z",
+          "scheduledTime": "2026-06-27T12:03:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "3",
-          "lineCode": "M-306",
-          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-26T12:06:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "8",
-          "lineCode": "M-316",
-          "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
-          "destination": "VILLABLANCA",
-          "scheduledTime": "2026-06-26T12:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "8",
-          "lineCode": "M-316",
-          "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
-          "destination": "VILLABLANCA",
-          "scheduledTime": "2026-06-26T12:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "66",
-          "lineCode": "M-902",
-          "lineName": "Ayamonte-Huelva-Sevilla",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-26T13:36:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-26T13:41:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "66",
-          "lineCode": "M-902",
-          "lineName": "Ayamonte-Huelva-Sevilla",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-26T13:52:00.000Z",
+          "scheduledTime": "2026-06-27T13:22:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T14:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T14:00:00.000Z"
       }
     },
     {
@@ -1774,73 +1317,55 @@
       "nucleus": "ISLA CRISTINA",
       "services": [
         {
-          "lineId": "7",
-          "lineCode": "M-314",
-          "lineName": "Isla Cristina-Ayamonte",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-26T10:30:00.000Z",
+          "scheduledTime": "2026-06-27T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "5",
-          "lineCode": "M-310",
-          "lineName": "Huelva-Isla Cristina-Ayamonte",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-26T11:14:00.000Z",
+          "scheduledTime": "2026-06-27T11:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-26T11:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "3",
-          "lineCode": "M-306",
-          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-26T11:20:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "7",
-          "lineCode": "M-314",
-          "lineName": "Isla Cristina-Ayamonte",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-26T11:30:00.000Z",
+          "scheduledTime": "2026-06-27T12:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "3",
-          "lineCode": "M-306",
-          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-26T12:29:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-26T13:20:00.000Z",
+          "scheduledTime": "2026-06-27T13:20:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "destination": "AYAMONTE",
+          "scheduledTime": "2026-06-27T14:00:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T14:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T14:00:00.000Z"
       }
     },
     {
@@ -1856,11 +1381,38 @@
       "nucleus": "ALMONTE",
       "services": [
         {
-          "lineId": "70",
-          "lineCode": "M-906",
-          "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
-          "destination": "ROCIANA DEL CONDADO",
-          "scheduledTime": "2026-06-26T12:28:00.000Z",
+          "lineId": "75",
+          "lineCode": "M-911",
+          "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-06-27T10:14:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-06-27T10:18:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-06-27T11:03:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "50",
+          "lineCode": "M-407",
+          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
+          "destination": "BOLLULLOS PAR DEL CONDADO",
+          "scheduledTime": "2026-06-27T12:47:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1869,25 +1421,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-06-26T12:33:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "48",
-          "lineCode": "M-405",
-          "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
-          "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-06-26T12:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "50",
-          "lineCode": "M-407",
-          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-26T13:17:00.000Z",
+          "scheduledTime": "2026-06-27T12:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1896,15 +1430,24 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-26T13:33:00.000Z",
+          "scheduledTime": "2026-06-27T13:33:00.000Z",
           "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "50",
+          "lineCode": "M-407",
+          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-06-27T13:47:00.000Z",
+          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T14:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T14:00:00.000Z"
       }
     },
     {
@@ -1920,9 +1463,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T14:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T14:00:00.000Z"
       }
     },
     {
@@ -1938,9 +1481,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-26T06:27:05.347Z",
-        "startTime": "2026-06-26T10:00:00.000Z",
-        "endTime": "2026-06-26T14:00:00.000Z"
+        "requestedAt": "2026-06-27T06:14:37.107Z",
+        "startTime": "2026-06-27T10:00:00.000Z",
+        "endTime": "2026-06-27T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:26:58.672Z",
+    "generatedAt": "2026-06-27T06:14:26.681Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:26:58.672Z",
+    "generatedAt": "2026-06-27T06:14:26.681Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:26:58.672Z",
+    "generatedAt": "2026-06-27T06:14:26.681Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:26:58.672Z",
+    "generatedAt": "2026-06-27T06:14:26.681Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:26:58.672Z",
+    "generatedAt": "2026-06-27T06:14:26.681Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:26:58.672Z",
+    "generatedAt": "2026-06-27T06:14:26.681Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:26:58.672Z",
+    "generatedAt": "2026-06-27T06:14:26.681Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:26:58.672Z",
+    "generatedAt": "2026-06-27T06:14:26.681Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:26:58.672Z",
+    "generatedAt": "2026-06-27T06:14:26.681Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-26T06:26:58.672Z",
+    "generatedAt": "2026-06-27T06:14:26.681Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-06-27 06:15 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed transit catalog data for multiple service groups.
  * Added several new route entries in one network, expanding available line coverage.

* **Bug Fixes**
  * Updated service snapshots and schedules to reflect the latest operating times.
  * Adjusted some route names to include newly stated travel restrictions.

* **Chores**
  * Regenerated metadata timestamps across catalog and stop-directory data assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->