### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,
     "consortiumName": "Área de Jaén",
-    "itemCount": 43
+    "itemCount": 42
   },
   "lines": [
     {
@@ -914,31 +914,6 @@
       "modeId": "1",
       "operators": [
         "Transportes Muñoz Amezcua",
-        "S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "60",
-      "code": "M14-1",
-      "name": "Noalejo - Jaén",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Transportes Romero",
         "S.L."
       ],
       "hasNews": false,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:31.513Z",
+    "generatedAt": "2026-06-28T06:31:49.649Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:37.107Z",
+    "generatedAt": "2026-06-28T06:31:53.283Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -19,9 +19,9 @@
       "nucleus": "FUENTE DEL REY (Dos Hermanas) zonaC",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -37,28 +37,19 @@
       "nucleus": "ESPARTINAS",
       "services": [
         {
-          "lineId": "284",
-          "lineCode": "1666",
-          "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-27T10:31:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
           "lineId": "295",
           "lineCode": "1681",
           "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-27T10:57:00.000Z",
+          "scheduledTime": "2026-06-28T10:27:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -78,24 +69,15 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-06-27T10:17:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "1720",
-          "lineName": "M-170A Santiponce - Sevilla",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-27T10:47:00.000Z",
+          "scheduledTime": "2026-06-28T10:02:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -111,9 +93,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -133,7 +115,7 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-27T10:04:00.000Z",
+          "scheduledTime": "2026-06-28T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -142,24 +124,15 @@
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-06-27T10:04:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "232",
-          "lineCode": "1100",
-          "lineName": "M-110 La Algaba - Sevilla",
-          "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-27T10:34:00.000Z",
+          "scheduledTime": "2026-06-28T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -179,7 +152,7 @@
           "lineCode": "M-560",
           "lineName": "Rota-Jerez De La Frontera",
           "destination": "Rota",
-          "scheduledTime": "2026-06-27T10:30:00.000Z",
+          "scheduledTime": "2026-06-28T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -188,15 +161,15 @@
           "lineCode": "M-560",
           "lineName": "Rota-Jerez De La Frontera",
           "destination": "Jerez",
-          "scheduledTime": "2026-06-27T11:00:00.000Z",
+          "scheduledTime": "2026-06-28T11:00:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -212,9 +185,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -234,7 +207,7 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-27T10:05:00.000Z",
+          "scheduledTime": "2026-06-28T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -243,7 +216,7 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Jerez",
-          "scheduledTime": "2026-06-27T10:05:00.000Z",
+          "scheduledTime": "2026-06-28T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -252,7 +225,7 @@
           "lineCode": "M-965",
           "lineName": "Chipiona-Sanlúcar De Barrameda (Sevilla/Utrera)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-27T10:11:00.000Z",
+          "scheduledTime": "2026-06-28T10:11:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -261,7 +234,7 @@
           "lineCode": "M-974",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar De Barrameda (Sevilla)",
           "destination": "Costa Ballena (Rota)",
-          "scheduledTime": "2026-06-27T10:12:00.000Z",
+          "scheduledTime": "2026-06-28T10:12:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -270,15 +243,15 @@
           "lineCode": "M-561",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
           "destination": "Jerez",
-          "scheduledTime": "2026-06-27T10:45:00.000Z",
+          "scheduledTime": "2026-06-28T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -294,9 +267,9 @@
       "nucleus": "Chiclana",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -316,7 +289,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-27T10:10:00.000Z",
+          "scheduledTime": "2026-06-28T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -325,15 +298,33 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-27T10:21:00.000Z",
+          "scheduledTime": "2026-06-28T10:21:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "9",
+          "lineCode": "M-031",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
+          "destination": "Puerto Real",
+          "scheduledTime": "2026-06-28T10:31:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "9",
+          "lineCode": "M-031",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
+          "destination": "Cádiz",
+          "scheduledTime": "2026-06-28T10:52:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -353,7 +344,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-27T10:21:00.000Z",
+          "scheduledTime": "2026-06-28T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -362,15 +353,15 @@
           "lineCode": "0226",
           "lineName": "Granada - P.Puente - Zujaira",
           "destination": "Zujaira",
-          "scheduledTime": "2026-06-27T11:49:00.000Z",
+          "scheduledTime": "2026-06-28T11:49:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T12:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T12:00:00.000Z"
       }
     },
     {
@@ -390,7 +381,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Centro Penitenciario de Albolote",
-          "scheduledTime": "2026-06-27T10:15:00.000Z",
+          "scheduledTime": "2026-06-28T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -399,7 +390,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Granada",
-          "scheduledTime": "2026-06-27T11:09:00.000Z",
+          "scheduledTime": "2026-06-28T10:54:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -408,15 +399,15 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Centro Penitenciario de Albolote",
-          "scheduledTime": "2026-06-27T11:45:00.000Z",
+          "scheduledTime": "2026-06-28T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T12:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T12:00:00.000Z"
       }
     },
     {
@@ -436,24 +427,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-27T10:27:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1119",
-          "lineCode": "0242",
-          "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
-          "destination": "Láchar",
-          "scheduledTime": "2026-06-27T11:27:00.000Z",
+          "scheduledTime": "2026-06-28T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T12:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T12:00:00.000Z"
       }
     },
     {
@@ -469,9 +451,9 @@
       "nucleus": "Cijuela",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T12:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T12:00:00.000Z"
       }
     },
     {
@@ -491,7 +473,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-27T10:00:00.000Z",
+          "scheduledTime": "2026-06-28T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -500,7 +482,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-27T10:01:00.000Z",
+          "scheduledTime": "2026-06-28T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -509,7 +491,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-27T10:45:00.000Z",
+          "scheduledTime": "2026-06-28T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -518,7 +500,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-06-27T11:15:00.000Z",
+          "scheduledTime": "2026-06-28T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -527,15 +509,15 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-27T11:31:00.000Z",
+          "scheduledTime": "2026-06-28T11:31:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T12:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T12:00:00.000Z"
       }
     },
     {
@@ -551,9 +533,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T10:15:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T10:15:00.000Z"
       }
     },
     {
@@ -569,9 +551,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T10:15:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T10:15:00.000Z"
       }
     },
     {
@@ -587,9 +569,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T10:15:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T10:15:00.000Z"
       }
     },
     {
@@ -605,9 +587,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T10:15:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T10:15:00.000Z"
       }
     },
     {
@@ -623,9 +605,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T10:15:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T10:15:00.000Z"
       }
     },
     {
@@ -641,9 +623,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -663,15 +645,15 @@
           "lineCode": "M-161",
           "lineName": "Barbate-Facinas-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-27T10:10:00.000Z",
+          "scheduledTime": "2026-06-28T10:10:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -690,25 +672,25 @@
           "lineId": "1",
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
-          "destination": "Los Barrios",
-          "scheduledTime": "2026-06-27T10:30:00.000Z",
-          "direction": 2,
+          "destination": "Algeciras",
+          "scheduledTime": "2026-06-28T10:30:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
           "lineId": "1",
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
-          "destination": "Algeciras",
-          "scheduledTime": "2026-06-27T10:30:00.000Z",
-          "direction": 1,
+          "destination": "Los Barrios",
+          "scheduledTime": "2026-06-28T10:30:00.000Z",
+          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -728,15 +710,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-27T10:03:00.000Z",
+          "scheduledTime": "2026-06-28T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -756,7 +738,7 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-27T10:45:00.000Z",
+          "scheduledTime": "2026-06-28T10:45:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -765,7 +747,7 @@
           "lineCode": "M-230",
           "lineName": "La Línea-San Roque",
           "destination": "La Línea de la Concepción",
-          "scheduledTime": "2026-06-27T10:45:00.000Z",
+          "scheduledTime": "2026-06-28T10:45:00.000Z",
           "direction": 2,
           "stopType": 1
         },
@@ -774,15 +756,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-06-27T11:00:00.000Z",
+          "scheduledTime": "2026-06-28T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -802,15 +784,15 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-06-27T10:33:00.000Z",
+          "scheduledTime": "2026-06-28T10:33:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -826,9 +808,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -844,9 +826,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -862,9 +844,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -880,9 +862,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T11:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T11:00:00.000Z"
       }
     },
     {
@@ -898,9 +880,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T12:30:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T12:30:00.000Z"
       }
     },
     {
@@ -919,17 +901,8 @@
           "lineId": "278",
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-27T10:28:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-27T10:35:00.000Z",
+          "scheduledTime": "2026-06-28T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -937,26 +910,26 @@
           "lineId": "283",
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
-          "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-27T11:00:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
-          "destination": "Fuensanta de Martos",
-          "scheduledTime": "2026-06-27T11:25:00.000Z",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-28T10:51:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "279",
-          "lineCode": "M20-02",
-          "lineName": "Jaén - Jamilena, 2024",
-          "destination": "Jamilena",
-          "scheduledTime": "2026-06-27T11:25:00.000Z",
+          "lineId": "289",
+          "lineCode": "M20-13",
+          "lineName": "Jaén - Jamilena - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-28T11:03:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "283",
+          "lineCode": "M20-06",
+          "lineName": "Jaén - Córdoba (Ruta), 2024",
+          "destination": "Torredonjimeno",
+          "scheduledTime": "2026-06-28T11:50:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -965,7 +938,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-27T11:55:00.000Z",
+          "scheduledTime": "2026-06-28T12:10:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -974,24 +947,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-27T12:08:00.000Z",
+          "scheduledTime": "2026-06-28T12:28:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "280",
-          "lineCode": "M20-03",
-          "lineName": "Jaén - Villardompardo, 2024",
-          "destination": "Villardompardo",
-          "scheduledTime": "2026-06-27T12:25:00.000Z",
-          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T12:30:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T12:30:00.000Z"
       }
     },
     {
@@ -1007,11 +971,20 @@
       "nucleus": "Torredonjimeno",
       "services": [
         {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
+          "lineId": "283",
+          "lineCode": "M20-06",
+          "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-27T10:15:00.000Z",
+          "scheduledTime": "2026-06-28T10:38:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "289",
+          "lineCode": "M20-13",
+          "lineName": "Jaén - Jamilena - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-06-28T10:45:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1020,7 +993,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-27T10:48:00.000Z",
+          "scheduledTime": "2026-06-28T10:48:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1029,17 +1002,8 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-27T11:13:00.000Z",
+          "scheduledTime": "2026-06-28T12:03:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
-          "destination": "Fuensanta de Martos",
-          "scheduledTime": "2026-06-27T11:38:00.000Z",
-          "direction": 2,
           "stopType": 0
         },
         {
@@ -1047,7 +1011,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-06-27T11:55:00.000Z",
+          "scheduledTime": "2026-06-28T12:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1056,15 +1020,15 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-06-27T12:08:00.000Z",
+          "scheduledTime": "2026-06-28T12:23:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T12:30:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T12:30:00.000Z"
       }
     },
     {
@@ -1083,34 +1047,16 @@
           "lineId": "203",
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-27T10:00:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "276",
-          "lineCode": "M15-7",
-          "lineName": "Jaén - Andújar - Marmolejo",
-          "destination": "Andújar",
-          "scheduledTime": "2026-06-27T10:55:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-06-27T11:00:00.000Z",
+          "scheduledTime": "2026-06-28T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T12:30:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T12:30:00.000Z"
       }
     },
     {
@@ -1124,39 +1070,11 @@
       },
       "municipality": "Mancha Real",
       "nucleus": "Mancha Real",
-      "services": [
-        {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-06-27T11:55:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "14",
-          "lineCode": "M1-5",
-          "lineName": "Quesada - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-06-27T12:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "22",
-          "lineCode": "M1-21",
-          "lineName": "Torres - Jaén",
-          "destination": "Torres",
-          "scheduledTime": "2026-06-27T12:25:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T12:30:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T12:30:00.000Z"
       }
     },
     {
@@ -1172,9 +1090,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-28T02:39:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-29T02:39:00.000Z"
       }
     },
     {
@@ -1190,9 +1108,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-28T02:39:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-29T02:39:00.000Z"
       }
     },
     {
@@ -1208,9 +1126,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-28T02:39:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-29T02:39:00.000Z"
       }
     },
     {
@@ -1226,9 +1144,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-28T02:39:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-29T02:39:00.000Z"
       }
     },
     {
@@ -1244,9 +1162,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-28T02:39:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-29T02:39:00.000Z"
       }
     },
     {
@@ -1266,7 +1184,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-27T10:03:00.000Z",
+          "scheduledTime": "2026-06-28T10:03:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1275,7 +1193,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-27T11:22:00.000Z",
+          "scheduledTime": "2026-06-28T11:22:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1284,7 +1202,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-27T12:03:00.000Z",
+          "scheduledTime": "2026-06-28T12:18:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1293,15 +1211,15 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-27T13:22:00.000Z",
+          "scheduledTime": "2026-06-28T13:22:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T14:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T14:00:00.000Z"
       }
     },
     {
@@ -1321,7 +1239,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-27T10:00:00.000Z",
+          "scheduledTime": "2026-06-28T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1330,7 +1248,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-27T11:20:00.000Z",
+          "scheduledTime": "2026-06-28T11:35:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1339,7 +1257,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-27T12:00:00.000Z",
+          "scheduledTime": "2026-06-28T12:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1348,7 +1266,7 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-06-27T13:20:00.000Z",
+          "scheduledTime": "2026-06-28T13:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1357,15 +1275,15 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-27T14:00:00.000Z",
+          "scheduledTime": "2026-06-28T14:00:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T14:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T14:00:00.000Z"
       }
     },
     {
@@ -1385,7 +1303,7 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-27T10:14:00.000Z",
+          "scheduledTime": "2026-06-28T10:14:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1394,25 +1312,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-27T10:18:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-27T11:03:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "50",
-          "lineCode": "M-407",
-          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
-          "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-06-27T12:47:00.000Z",
+          "scheduledTime": "2026-06-28T10:18:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1421,7 +1321,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-06-27T12:48:00.000Z",
+          "scheduledTime": "2026-06-28T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1430,24 +1330,15 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-27T13:33:00.000Z",
+          "scheduledTime": "2026-06-28T13:33:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "50",
-          "lineCode": "M-407",
-          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-27T13:47:00.000Z",
-          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T14:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T14:00:00.000Z"
       }
     },
     {
@@ -1463,9 +1354,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T14:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T14:00:00.000Z"
       }
     },
     {
@@ -1481,9 +1372,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-27T06:14:37.107Z",
-        "startTime": "2026-06-27T10:00:00.000Z",
-        "endTime": "2026-06-27T14:00:00.000Z"
+        "requestedAt": "2026-06-28T06:31:53.283Z",
+        "startTime": "2026-06-28T10:00:00.000Z",
+        "endTime": "2026-06-28T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:26.681Z",
+    "generatedAt": "2026-06-28T06:31:46.055Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:26.681Z",
+    "generatedAt": "2026-06-28T06:31:46.055Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:26.681Z",
+    "generatedAt": "2026-06-28T06:31:46.055Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:26.681Z",
+    "generatedAt": "2026-06-28T06:31:46.055Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:26.681Z",
+    "generatedAt": "2026-06-28T06:31:46.055Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:26.681Z",
+    "generatedAt": "2026-06-28T06:31:46.055Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:26.681Z",
+    "generatedAt": "2026-06-28T06:31:46.055Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:26.681Z",
+    "generatedAt": "2026-06-28T06:31:46.055Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:26.681Z",
+    "generatedAt": "2026-06-28T06:31:46.055Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-27T06:14:26.681Z",
+    "generatedAt": "2026-06-28T06:31:46.055Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-06-28 06:32 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Refreshed catalog and stop-directory data timestamps across multiple transit datasets.
  * Updated a stop-services snapshot with newer timetable results and service times.
  * Removed one outdated line from a consortium line list, reducing the total entry count accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->