### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,42 +1,17 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,
     "consortiumName": "Área de Sevilla",
-    "itemCount": 123
+    "itemCount": 117
   },
   "lines": [
     {
       "id": "259",
       "code": "1011",
       "name": "M-101A Circular Bormujos - Castilleja - Tomares - S Juan A - Mairena (sent A)",
-      "mode": "Bus",
-      "modeId": "1",
-      "operators": [
-        "DAMAS S.A",
-        "TRANVIAS DE SEVILLA S.A"
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "298",
-      "code": "1013",
-      "name": "M-101B Circular Bormujos - Mairena - S Juan A - Tomares - Castilleja (sent B)",
       "mode": "Bus",
       "modeId": "1",
       "operators": [
@@ -445,30 +420,6 @@
       "inboundPath": []
     },
     {
-      "id": "209",
-      "code": "1121",
-      "name": "M-112 La Rinconada - Sevilla (Directo)",
-      "mode": "Bus",
-      "modeId": "1",
-      "operators": [
-        "CASAL S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "208",
       "code": "1120",
       "name": "M-112 San José de la Rinconada-  Sevilla (por La Rinconada)",
@@ -613,30 +564,6 @@
       "inboundPath": []
     },
     {
-      "id": "468",
-      "code": "1213",
-      "name": "M-121  Alcalá de Guadaíra - Sevilla (nocturno-sábados)",
-      "mode": "Bus",
-      "modeId": "1",
-      "operators": [
-        "CASAL S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "438",
       "code": "1211",
       "name": "M-121  Alcalá de Guadaíra - Sevilla (parada en Goya y Hda Dolores)",
@@ -757,30 +684,6 @@
       "inboundPath": []
     },
     {
-      "id": "501",
-      "code": "1231",
-      "name": "M-123B Alcalá de Guadaíra - Univ Pablo de Olavide (UPO)",
-      "mode": "Bus",
-      "modeId": "1",
-      "operators": [
-        "CASAL S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "221",
       "code": "1241",
       "name": "M-124 Carmona - El Viso del Alcor - Sevilla",
@@ -880,30 +783,6 @@
       "id": "498",
       "code": "1245",
       "name": "M-124 El Corzo, La Celada (Carmona) - Sevilla (servicio a demanda)",
-      "mode": "Bus",
-      "modeId": "1",
-      "operators": [
-        "CASAL S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "222",
-      "code": "1242",
-      "name": "M-124 Sevilla - Carmona -  La Campana (directo, Est Prado)",
       "mode": "Bus",
       "modeId": "1",
       "operators": [
@@ -1744,30 +1623,6 @@
       "id": "420",
       "code": "1581",
       "name": "M-158 Bollullos de la Mitación - Sevilla (por El Barrero, Bormujos)",
-      "mode": "Bus",
-      "modeId": "1",
-      "operators": [
-        "DAMAS S.A"
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "276",
-      "code": "1591",
-      "name": "M-159 Bollullos de la Mitación - Sevilla (por A-49)",
       "mode": "Bus",
       "modeId": "1",
       "operators": [

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,
     "consortiumName": "Área de Granada",
-    "itemCount": 72
+    "itemCount": 70
   },
   "lines": [
     {
@@ -412,31 +412,6 @@
       "id": "1114",
       "code": "0153",
       "name": "Granada - Churriana V. - Híjar (Directo)",
-      "mode": "AUTOBUS",
-      "modeId": "1",
-      "operators": [
-        "NEX Continental Holdings",
-        "S.L.U."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "1123",
-      "code": "0256C",
-      "name": "Granada - CITAI",
       "mode": "AUTOBUS",
       "modeId": "1",
       "operators": [
@@ -1186,31 +1161,6 @@
       "id": "1049",
       "code": "0361",
       "name": "Granada - Padul - Marchena - Dúrcal - Nigüelas",
-      "mode": "AUTOBUS",
-      "modeId": "1",
-      "operators": [
-        "NEX Continental Holdings",
-        "S.L.U."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "1099",
-      "code": "0110",
-      "name": "Granada - Peligros -Caserío Fonseca - Monteluz",
       "mode": "AUTOBUS",
       "modeId": "1",
       "operators": [

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,
     "consortiumName": "Área de Jaén",
-    "itemCount": 42
+    "itemCount": 30
   },
   "lines": [
     {
@@ -16,31 +16,6 @@
       "modeId": "1",
       "operators": [
         "Transportes Muñoz Amezcua",
-        "S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "216",
-      "code": "M15-3",
-      "name": "Andújar - Jaén",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Autocares Marcos Muñoz",
         "S.L."
       ],
       "hasNews": false,
@@ -233,31 +208,6 @@
       "inboundPath": []
     },
     {
-      "id": "321",
-      "code": "M15-6",
-      "name": "Jaén - Andújar - Lopera",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Autocares Marcos Muñoz",
-        "S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "276",
       "code": "M15-7",
       "name": "Jaén - Andújar - Marmolejo",
@@ -266,31 +216,6 @@
       "operators": [
         "Autocares Marcos Muñoz",
         "S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "322",
-      "code": "M20-22",
-      "name": "Jaén - Ciudad Jardín (La Guardia)",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Autocares Samar",
-        "S.A."
       ],
       "hasNews": false,
       "concession": null,
@@ -341,31 +266,6 @@
       "operators": [
         "Autocares Samar",
         "S.A."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "61",
-      "code": "M15-1",
-      "name": "Jaén - Fuerte Del Rey",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Autocares Marcos Muñoz",
-        "S.L."
       ],
       "hasNews": false,
       "concession": null,
@@ -533,31 +433,6 @@
       "inboundPath": []
     },
     {
-      "id": "282",
-      "code": "M20-05",
-      "name": "Jaén - Martos (Directo), 2024",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Autocares Samar",
-        "S.A."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "278",
       "code": "M20-01",
       "name": "Jaén - Martos, 2024",
@@ -583,31 +458,6 @@
       "inboundPath": []
     },
     {
-      "id": "205",
-      "code": "M04-15",
-      "name": "Jaén - Mengibar",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Autocares Jaén",
-        "S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "325",
       "code": "M11-01",
       "name": "Jaén - Pegalajar (2026)",
@@ -616,31 +466,6 @@
       "operators": [
         "Autocares Montijano",
         "S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "326",
-      "code": "M10-01",
-      "name": "Jaén - Sotogordo Por Vados De Torralba(2026)",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Autocares Samar",
-        "S.A."
       ],
       "hasNews": false,
       "concession": null,
@@ -733,31 +558,6 @@
       "inboundPath": []
     },
     {
-      "id": "327",
-      "code": "M10-02",
-      "name": "Jaén - Villargordo (2026)",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Autocares Samar",
-        "S.A."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "34",
       "code": "M3-80",
       "name": "Jaén - Villarrodrigo",
@@ -782,31 +582,6 @@
       "inboundPath": []
     },
     {
-      "id": "324",
-      "code": "M10-03",
-      "name": "Jaén -Torreblascopedro Por Vados de Torralba (2026)",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Autocares Samar",
-        "S.A."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "254",
       "code": "M15-4",
       "name": "Jaén-Lahiguera-Arjona-Andújar",
@@ -814,31 +589,6 @@
       "modeId": "1",
       "operators": [
         "Autocares Marcos Muñoz",
-        "S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "15",
-      "code": "M1-6",
-      "name": "Jódar - Jaén",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Transportes Muñoz Amezcua",
         "S.L."
       ],
       "hasNews": false,
@@ -910,56 +660,6 @@
       "id": "17",
       "code": "M1-9",
       "name": "Mancha Real - Jaén",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Transportes Muñoz Amezcua",
-        "S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "21",
-      "code": "M1-20",
-      "name": "Pozo Alcón - Jaén",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Transportes Muñoz Amezcua",
-        "S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "14",
-      "code": "M1-5",
-      "name": "Quesada - Jaén",
       "mode": "Autobús",
       "modeId": "1",
       "operators": [

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,41 +1,17 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,
     "consortiumName": "Costa de Huelva",
-    "itemCount": 53
+    "itemCount": 46
   },
   "lines": [
     {
       "id": "59",
       "code": "M-416",
       "name": "Almonte-Torre Higuera",
-      "mode": "AUTOBUS",
-      "modeId": "2",
-      "operators": [
-        "DAMAS SA"
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "9",
-      "code": "M-318",
-      "name": "Ayamonte-El Almendro",
       "mode": "AUTOBUS",
       "modeId": "2",
       "operators": [
@@ -225,30 +201,6 @@
       "inboundPath": []
     },
     {
-      "id": "28",
-      "code": "M-209",
-      "name": "Huelva-Aracena-Hinojales-Cumbres Mayores",
-      "mode": "AUTOBUS",
-      "modeId": "2",
-      "operators": [
-        "DAMAS SA"
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "8",
       "code": "M-316",
       "name": "Huelva-Ayamonte-San Silvestre De Guzman",
@@ -417,30 +369,6 @@
       "inboundPath": []
     },
     {
-      "id": "3",
-      "code": "M-306",
-      "name": "Huelva-Corrales-La Redondela-Isla Cristina",
-      "mode": "AUTOBUS",
-      "modeId": "2",
-      "operators": [
-        "DAMAS SA"
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "26",
       "code": "M-207",
       "name": "Huelva-Cortegana-Aroche",
@@ -540,30 +468,6 @@
       "id": "5",
       "code": "M-310",
       "name": "Huelva-Isla Cristina-Ayamonte",
-      "mode": "AUTOBUS",
-      "modeId": "2",
-      "operators": [
-        "DAMAS SA"
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "17",
-      "code": "M-102",
-      "name": "Huelva-La Alqueria-Centro Penitenciario",
       "mode": "AUTOBUS",
       "modeId": "2",
       "operators": [
@@ -849,30 +753,6 @@
       "inboundPath": []
     },
     {
-      "id": "43",
-      "code": "M-400",
-      "name": "Huelva-San Juan Del Puerto-Moguer",
-      "mode": "AUTOBUS",
-      "modeId": "2",
-      "operators": [
-        "DAMAS SA"
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "64",
       "code": "M-900",
       "name": "Huelva-Sevilla Por CN-431",
@@ -969,30 +849,6 @@
       "inboundPath": []
     },
     {
-      "id": "31",
-      "code": "M-212",
-      "name": "Huelva-Valverde Del Camino-El Cerro Del Andevalo",
-      "mode": "AUTOBUS",
-      "modeId": "2",
-      "operators": [
-        "DAMAS SA"
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "20",
       "code": "M-201",
       "name": "Huelva-Villanueva De Los Castillejos-Paymogo",
@@ -1044,30 +900,6 @@
       "id": "30",
       "code": "M-211",
       "name": "Huelva-Villanueva De Los Castillejos-Santa Barbara",
-      "mode": "AUTOBUS",
-      "modeId": "2",
-      "operators": [
-        "DAMAS SA"
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "7",
-      "code": "M-314",
-      "name": "Isla Cristina-Ayamonte",
       "mode": "AUTOBUS",
       "modeId": "2",
       "operators": [

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:53.512Z",
+    "generatedAt": "2026-06-30T06:29:23.521Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:57.269Z",
+    "generatedAt": "2026-06-30T06:29:26.910Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -17,30 +17,11 @@
       },
       "municipality": "DOS HERMANAS",
       "nucleus": "FUENTE DEL REY (Dos Hermanas) zonaC",
-      "services": [
-        {
-          "lineId": "242",
-          "lineCode": "1320",
-          "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-29T10:07:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "242",
-          "lineCode": "1320",
-          "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-29T10:37:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -54,48 +35,11 @@
       },
       "municipality": "ESPARTINAS",
       "nucleus": "ESPARTINAS",
-      "services": [
-        {
-          "lineId": "284",
-          "lineCode": "1666",
-          "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-29T10:31:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "295",
-          "lineCode": "1681",
-          "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-29T10:42:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "290",
-          "lineCode": "1020",
-          "lineName": "M-102A Circular Aljarafe (sentido A)",
-          "destination": "SANLUCAR LA MAYOR",
-          "scheduledTime": "2026-06-29T10:46:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "279",
-          "lineCode": "1661",
-          "lineName": "M-166 Sanlúcar la Mayor - Sevilla",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-29T10:48:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -109,30 +53,11 @@
       },
       "municipality": "SANTIPONCE",
       "nucleus": "SANTIPONCE",
-      "services": [
-        {
-          "lineId": "287",
-          "lineCode": "1720",
-          "lineName": "M-170A Santiponce - Sevilla",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-29T10:02:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "1720",
-          "lineName": "M-170A Santiponce - Sevilla",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-06-29T10:32:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -148,9 +73,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -164,39 +89,11 @@
       },
       "municipality": "SEVILLA",
       "nucleus": "SEVILLA",
-      "services": [
-        {
-          "lineId": "232",
-          "lineCode": "1100",
-          "lineName": "M-110 La Algaba - Sevilla",
-          "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-29T10:04:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "238",
-          "lineCode": "2160",
-          "lineName": "M-216 Brenes - Sevilla",
-          "destination": "BRENES",
-          "scheduledTime": "2026-06-29T10:04:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "232",
-          "lineCode": "1100",
-          "lineName": "M-110 La Algaba - Sevilla",
-          "destination": "LA ALGABA",
-          "scheduledTime": "2026-06-29T10:34:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -216,15 +113,15 @@
           "lineCode": "M-560",
           "lineName": "Rota-Jerez De La Frontera",
           "destination": "Rota",
-          "scheduledTime": "2026-06-29T10:00:00.000Z",
+          "scheduledTime": "2026-06-30T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -240,9 +137,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -258,30 +155,12 @@
       "nucleus": "Sanlúcar de Barrameda",
       "services": [
         {
-          "lineId": "225",
-          "lineCode": "M-967",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
-          "destination": "Cádiz",
-          "scheduledTime": "2026-06-29T10:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
           "lineId": "167",
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Jerez",
-          "scheduledTime": "2026-06-29T10:05:00.000Z",
+          "scheduledTime": "2026-06-30T10:05:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "225",
-          "lineCode": "M-967",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
-          "destination": "Chipiona",
-          "scheduledTime": "2026-06-29T10:28:00.000Z",
-          "direction": 2,
           "stopType": 0
         },
         {
@@ -289,7 +168,7 @@
           "lineCode": "M-561",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
           "destination": "Jerez",
-          "scheduledTime": "2026-06-29T10:45:00.000Z",
+          "scheduledTime": "2026-06-30T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -298,15 +177,15 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-29T10:50:00.000Z",
+          "scheduledTime": "2026-06-30T10:50:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -326,7 +205,7 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-29T10:16:00.000Z",
+          "scheduledTime": "2026-06-30T10:16:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -335,15 +214,15 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Chiclana",
-          "scheduledTime": "2026-06-29T10:44:00.000Z",
+          "scheduledTime": "2026-06-30T10:44:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -363,7 +242,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-29T10:05:00.000Z",
+          "scheduledTime": "2026-06-30T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -372,16 +251,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-29T10:10:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "163",
-          "lineCode": "M-960",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
-          "destination": "Chipiona",
-          "scheduledTime": "2026-06-29T10:21:00.000Z",
+          "scheduledTime": "2026-06-30T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -390,7 +260,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-29T10:35:00.000Z",
+          "scheduledTime": "2026-06-30T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -399,7 +269,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-29T10:40:00.000Z",
+          "scheduledTime": "2026-06-30T10:40:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -408,7 +278,7 @@
           "lineCode": "M-031",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
           "destination": "Puerto Real",
-          "scheduledTime": "2026-06-29T10:51:00.000Z",
+          "scheduledTime": "2026-06-30T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -417,15 +287,15 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-29T11:00:00.000Z",
+          "scheduledTime": "2026-06-30T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -441,11 +311,11 @@
       "nucleus": "Granada",
       "services": [
         {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-29T10:21:00.000Z",
+          "lineId": "1077",
+          "lineCode": "0124",
+          "lineName": "Granada - Atarfe",
+          "destination": "Atarfe",
+          "scheduledTime": "2026-06-30T10:28:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -454,16 +324,7 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-06-29T10:28:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-29T10:51:00.000Z",
+          "scheduledTime": "2026-06-30T11:08:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -472,42 +333,15 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-06-29T11:08:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-29T11:21:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "1077",
-          "lineCode": "0124",
-          "lineName": "Granada - Atarfe",
-          "destination": "Atarfe",
-          "scheduledTime": "2026-06-29T11:48:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-06-29T11:51:00.000Z",
+          "scheduledTime": "2026-06-30T11:48:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T12:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T12:00:00.000Z"
       }
     },
     {
@@ -527,7 +361,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Granada",
-          "scheduledTime": "2026-06-29T10:39:00.000Z",
+          "scheduledTime": "2026-06-30T10:39:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -536,7 +370,7 @@
           "lineCode": "0318",
           "lineName": "Granada - Colomera",
           "destination": "Cerro Cauro",
-          "scheduledTime": "2026-06-29T10:41:00.000Z",
+          "scheduledTime": "2026-06-30T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -545,15 +379,15 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Parque del Cubillas",
-          "scheduledTime": "2026-06-29T11:30:00.000Z",
+          "scheduledTime": "2026-06-30T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T12:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T12:00:00.000Z"
       }
     },
     {
@@ -573,7 +407,7 @@
           "lineCode": "0241",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
           "destination": "Cijuela",
-          "scheduledTime": "2026-06-29T10:26:00.000Z",
+          "scheduledTime": "2026-06-30T10:26:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -582,7 +416,7 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-29T11:27:00.000Z",
+          "scheduledTime": "2026-06-30T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -591,15 +425,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-29T11:57:00.000Z",
+          "scheduledTime": "2026-06-30T11:57:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T12:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T12:00:00.000Z"
       }
     },
     {
@@ -619,15 +453,15 @@
           "lineCode": "0340",
           "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
           "destination": "Granada",
-          "scheduledTime": "2026-06-29T11:01:00.000Z",
+          "scheduledTime": "2026-06-30T11:01:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T12:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T12:00:00.000Z"
       }
     },
     {
@@ -641,75 +475,11 @@
       },
       "municipality": "Vegas del Genil",
       "nucleus": "Ambroz",
-      "services": [
-        {
-          "lineId": "1113",
-          "lineCode": "0150",
-          "lineName": "Granada - Cúllar V. - V. del Genil",
-          "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-29T10:01:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1042",
-          "lineCode": "0154",
-          "lineName": "Granada-V. del Genil (Directo)",
-          "destination": "Granada",
-          "scheduledTime": "2026-06-29T10:30:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "1042",
-          "lineCode": "0154",
-          "lineName": "Granada-V. del Genil (Directo)",
-          "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-29T10:35:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1042",
-          "lineCode": "0154",
-          "lineName": "Granada-V. del Genil (Directo)",
-          "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-29T11:15:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1042",
-          "lineCode": "0154",
-          "lineName": "Granada-V. del Genil (Directo)",
-          "destination": "Granada",
-          "scheduledTime": "2026-06-29T11:15:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "1113",
-          "lineCode": "0150",
-          "lineName": "Granada - Cúllar V. - V. del Genil",
-          "destination": "El Ventorrillo",
-          "scheduledTime": "2026-06-29T11:46:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1042",
-          "lineCode": "0154",
-          "lineName": "Granada-V. del Genil (Directo)",
-          "destination": "Granada",
-          "scheduledTime": "2026-06-29T11:55:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T12:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T12:00:00.000Z"
       }
     },
     {
@@ -729,15 +499,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-29T10:11:00.000Z",
+          "scheduledTime": "2026-06-30T10:11:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T10:15:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T10:15:00.000Z"
       }
     },
     {
@@ -757,15 +527,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-29T10:08:00.000Z",
+          "scheduledTime": "2026-06-30T10:08:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T10:15:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T10:15:00.000Z"
       }
     },
     {
@@ -781,9 +551,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T10:15:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T10:15:00.000Z"
       }
     },
     {
@@ -803,15 +573,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-29T10:05:00.000Z",
+          "scheduledTime": "2026-06-30T10:05:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T10:15:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T10:15:00.000Z"
       }
     },
     {
@@ -831,15 +601,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-29T10:02:00.000Z",
+          "scheduledTime": "2026-06-30T10:02:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T10:15:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T10:15:00.000Z"
       }
     },
     {
@@ -855,9 +625,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -877,7 +647,7 @@
           "lineCode": "M-161",
           "lineName": "Barbate-Facinas-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-29T10:10:00.000Z",
+          "scheduledTime": "2026-06-30T10:10:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -886,15 +656,15 @@
           "lineCode": "M-150",
           "lineName": "Algeciras-Tarifa",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-29T10:45:00.000Z",
+          "scheduledTime": "2026-06-30T10:45:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -914,7 +684,7 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-29T10:30:00.000Z",
+          "scheduledTime": "2026-06-30T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -923,15 +693,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-29T10:30:00.000Z",
+          "scheduledTime": "2026-06-30T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -951,15 +721,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-29T10:03:00.000Z",
+          "scheduledTime": "2026-06-30T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -979,7 +749,7 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-29T10:45:00.000Z",
+          "scheduledTime": "2026-06-30T10:45:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -988,15 +758,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-06-29T11:00:00.000Z",
+          "scheduledTime": "2026-06-30T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -1016,7 +786,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ADRA",
-          "scheduledTime": "2026-06-29T10:36:00.000Z",
+          "scheduledTime": "2026-06-30T10:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1025,7 +795,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-06-29T10:48:00.000Z",
+          "scheduledTime": "2026-06-30T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1034,15 +804,15 @@
           "lineCode": "M-384",
           "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
           "destination": "ADRA",
-          "scheduledTime": "2026-06-29T10:51:00.000Z",
+          "scheduledTime": "2026-06-30T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -1058,9 +828,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -1076,9 +846,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -1094,9 +864,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -1112,9 +882,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T11:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T11:00:00.000Z"
       }
     },
     {
@@ -1130,9 +900,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T12:30:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T12:30:00.000Z"
       }
     },
     {
@@ -1146,156 +916,11 @@
       },
       "municipality": "Torredelcampo",
       "nucleus": "Torredelcampo",
-      "services": [
-        {
-          "lineId": "279",
-          "lineCode": "M20-02",
-          "lineName": "Jaén - Jamilena, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T10:13:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-29T10:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "286",
-          "lineCode": "M20-10",
-          "lineName": "Jaén - Torredelcampo, 2024",
-          "destination": "Torredelcampo",
-          "scheduledTime": "2026-06-29T10:25:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T10:28:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "286",
-          "lineCode": "M20-10",
-          "lineName": "Jaén - Torredelcampo, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T10:33:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T10:38:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "283",
-          "lineCode": "M20-06",
-          "lineName": "Jaén - Córdoba (Ruta), 2024",
-          "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-29T10:40:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-29T11:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-29T11:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "286",
-          "lineCode": "M20-10",
-          "lineName": "Jaén - Torredelcampo, 2024",
-          "destination": "Torredelcampo",
-          "scheduledTime": "2026-06-29T11:25:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T11:28:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "288",
-          "lineCode": "M20-12",
-          "lineName": "Jaén - Escañuela, 2024",
-          "destination": "Escañuela",
-          "scheduledTime": "2026-06-29T11:55:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "285",
-          "lineCode": "M20-08",
-          "lineName": "Jaén - Lopera, 2024",
-          "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-29T12:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-29T12:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "281",
-          "lineCode": "M20-04",
-          "lineName": "Jaén - Alcaudete, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-29T12:25:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T12:28:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T12:30:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T12:30:00.000Z"
       }
     },
     {
@@ -1309,93 +934,11 @@
       },
       "municipality": "Torredonjimeno",
       "nucleus": "Torredonjimeno",
-      "services": [
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T10:15:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T10:25:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-29T10:33:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "283",
-          "lineCode": "M20-06",
-          "lineName": "Jaén - Córdoba (Ruta), 2024",
-          "destination": "Torredonjimeno",
-          "scheduledTime": "2026-06-29T10:53:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T11:15:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-29T11:18:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-06-29T11:33:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "288",
-          "lineCode": "M20-12",
-          "lineName": "Jaén - Escañuela, 2024",
-          "destination": "Escañuela",
-          "scheduledTime": "2026-06-29T12:08:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T12:15:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T12:30:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T12:30:00.000Z"
       }
     },
     {
@@ -1409,84 +952,11 @@
       },
       "municipality": "Mengibar",
       "nucleus": "Mengíbar",
-      "services": [
-        {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T10:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-06-29T10:10:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-06-29T10:15:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T10:45:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-06-29T11:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-06-29T11:25:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T11:30:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-06-29T11:55:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T12:30:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T12:30:00.000Z"
       }
     },
     {
@@ -1502,55 +972,19 @@
       "nucleus": "Mancha Real",
       "services": [
         {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-06-29T10:45:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
           "lineId": "35",
           "lineCode": "M3-103",
           "lineName": "Úbeda - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-29T11:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-06-29T11:25:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "21",
-          "lineCode": "M1-20",
-          "lineName": "Pozo Alcón - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-06-29T12:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "14",
-          "lineCode": "M1-5",
-          "lineName": "Quesada - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-06-29T12:00:00.000Z",
+          "scheduledTime": "2026-06-30T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T12:30:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T12:30:00.000Z"
       }
     },
     {
@@ -1566,9 +1000,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-30T02:39:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-07-01T02:39:00.000Z"
       }
     },
     {
@@ -1584,9 +1018,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-30T02:39:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-07-01T02:39:00.000Z"
       }
     },
     {
@@ -1602,9 +1036,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-30T02:39:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-07-01T02:39:00.000Z"
       }
     },
     {
@@ -1620,9 +1054,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-30T02:39:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-07-01T02:39:00.000Z"
       }
     },
     {
@@ -1638,9 +1072,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-30T02:39:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-07-01T02:39:00.000Z"
       }
     },
     {
@@ -1654,111 +1088,11 @@
       },
       "municipality": "LEPE",
       "nucleus": "LEPE",
-      "services": [
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-29T10:05:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-29T10:41:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "5",
-          "lineCode": "M-310",
-          "lineName": "Huelva-Isla Cristina-Ayamonte",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-29T11:34:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "66",
-          "lineCode": "M-902",
-          "lineName": "Ayamonte-Huelva-Sevilla",
-          "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-29T11:36:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "3",
-          "lineCode": "M-306",
-          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-29T11:44:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "3",
-          "lineCode": "M-306",
-          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-29T12:06:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "8",
-          "lineCode": "M-316",
-          "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
-          "destination": "VILLABLANCA",
-          "scheduledTime": "2026-06-29T12:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "8",
-          "lineCode": "M-316",
-          "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
-          "destination": "VILLABLANCA",
-          "scheduledTime": "2026-06-29T12:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "66",
-          "lineCode": "M-902",
-          "lineName": "Ayamonte-Huelva-Sevilla",
-          "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-29T13:36:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-29T13:41:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "66",
-          "lineCode": "M-902",
-          "lineName": "Ayamonte-Huelva-Sevilla",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-29T13:52:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T14:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T14:00:00.000Z"
       }
     },
     {
@@ -1772,75 +1106,11 @@
       },
       "municipality": "ISLA CRISTINA",
       "nucleus": "ISLA CRISTINA",
-      "services": [
-        {
-          "lineId": "7",
-          "lineCode": "M-314",
-          "lineName": "Isla Cristina-Ayamonte",
-          "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-29T10:30:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "5",
-          "lineCode": "M-310",
-          "lineName": "Huelva-Isla Cristina-Ayamonte",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-29T11:14:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-29T11:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "3",
-          "lineCode": "M-306",
-          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-29T11:20:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "7",
-          "lineCode": "M-314",
-          "lineName": "Isla Cristina-Ayamonte",
-          "destination": "AYAMONTE",
-          "scheduledTime": "2026-06-29T11:30:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "3",
-          "lineCode": "M-306",
-          "lineName": "Huelva-Corrales-La Redondela-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-06-29T12:29:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-29T13:20:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T14:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T14:00:00.000Z"
       }
     },
     {
@@ -1854,57 +1124,11 @@
       },
       "municipality": "ALMONTE",
       "nucleus": "ALMONTE",
-      "services": [
-        {
-          "lineId": "70",
-          "lineCode": "M-906",
-          "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
-          "destination": "ROCIANA DEL CONDADO",
-          "scheduledTime": "2026-06-29T12:28:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "ALMONTE",
-          "scheduledTime": "2026-06-29T12:33:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "48",
-          "lineCode": "M-405",
-          "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
-          "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-06-29T12:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "50",
-          "lineCode": "M-407",
-          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-06-29T13:17:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-06-29T13:33:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T14:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T14:00:00.000Z"
       }
     },
     {
@@ -1920,9 +1144,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T14:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T14:00:00.000Z"
       }
     },
     {
@@ -1938,9 +1162,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-29T06:35:57.269Z",
-        "startTime": "2026-06-29T10:00:00.000Z",
-        "endTime": "2026-06-29T14:00:00.000Z"
+        "requestedAt": "2026-06-30T06:29:26.910Z",
+        "startTime": "2026-06-30T10:00:00.000Z",
+        "endTime": "2026-06-30T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:50.383Z",
+    "generatedAt": "2026-06-30T06:29:20.188Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:50.383Z",
+    "generatedAt": "2026-06-30T06:29:20.188Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:50.383Z",
+    "generatedAt": "2026-06-30T06:29:20.188Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:50.383Z",
+    "generatedAt": "2026-06-30T06:29:20.188Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:50.383Z",
+    "generatedAt": "2026-06-30T06:29:20.188Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:50.383Z",
+    "generatedAt": "2026-06-30T06:29:20.188Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:50.383Z",
+    "generatedAt": "2026-06-30T06:29:20.188Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:50.383Z",
+    "generatedAt": "2026-06-30T06:29:20.188Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:50.383Z",
+    "generatedAt": "2026-06-30T06:29:20.188Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-29T06:35:50.383Z",
+    "generatedAt": "2026-06-30T06:29:20.188Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-06-30 06:30 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed transit catalog and stop data with the latest generation timestamps.
  * Updated stop-service snapshots to reflect current schedules and availability.

* **Bug Fixes**
  * Removed several outdated route entries from multiple catalogs.
  * Adjusted item counts to match the updated available services and lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->