### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:23.521Z",
+    "generatedAt": "2026-07-01T06:33:13.729Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:26.910Z",
+    "generatedAt": "2026-07-01T06:33:17.530Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -17,11 +17,21 @@
       },
       "municipality": "DOS HERMANAS",
       "nucleus": "FUENTE DEL REY (Dos Hermanas) zonaC",
-      "services": [],
+      "services": [
+        {
+          "lineId": "242",
+          "lineCode": "1320",
+          "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-07-01T10:07:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -35,11 +45,39 @@
       },
       "municipality": "ESPARTINAS",
       "nucleus": "ESPARTINAS",
-      "services": [],
+      "services": [
+        {
+          "lineId": "284",
+          "lineCode": "1666",
+          "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-07-01T10:31:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "295",
+          "lineCode": "1681",
+          "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-07-01T10:42:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "279",
+          "lineCode": "1661",
+          "lineName": "M-166 Sanlúcar la Mayor - Sevilla",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-07-01T10:48:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -53,11 +91,30 @@
       },
       "municipality": "SANTIPONCE",
       "nucleus": "SANTIPONCE",
-      "services": [],
+      "services": [
+        {
+          "lineId": "287",
+          "lineCode": "1720",
+          "lineName": "M-170A Santiponce - Sevilla",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-07-01T10:02:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "287",
+          "lineCode": "1720",
+          "lineName": "M-170A Santiponce - Sevilla",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-07-01T10:32:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -73,9 +130,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -89,11 +146,39 @@
       },
       "municipality": "SEVILLA",
       "nucleus": "SEVILLA",
-      "services": [],
+      "services": [
+        {
+          "lineId": "232",
+          "lineCode": "1100",
+          "lineName": "M-110 La Algaba - Sevilla",
+          "destination": "LA ALGABA",
+          "scheduledTime": "2026-07-01T10:04:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "238",
+          "lineCode": "2160",
+          "lineName": "M-216 Brenes - Sevilla",
+          "destination": "BRENES",
+          "scheduledTime": "2026-07-01T10:04:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "232",
+          "lineCode": "1100",
+          "lineName": "M-110 La Algaba - Sevilla",
+          "destination": "LA ALGABA",
+          "scheduledTime": "2026-07-01T10:34:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -113,15 +198,15 @@
           "lineCode": "M-560",
           "lineName": "Rota-Jerez De La Frontera",
           "destination": "Rota",
-          "scheduledTime": "2026-06-30T10:00:00.000Z",
+          "scheduledTime": "2026-07-01T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -137,9 +222,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -155,11 +240,38 @@
       "nucleus": "Sanlúcar de Barrameda",
       "services": [
         {
+          "lineId": "225",
+          "lineCode": "M-967",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
+          "destination": "Cádiz",
+          "scheduledTime": "2026-07-01T10:05:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
           "lineId": "167",
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Jerez",
-          "scheduledTime": "2026-06-30T10:05:00.000Z",
+          "scheduledTime": "2026-07-01T10:05:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "225",
+          "lineCode": "M-967",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
+          "destination": "Chipiona",
+          "scheduledTime": "2026-07-01T10:28:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "165",
+          "lineCode": "M-962",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-San Fernando (Por Puerto Real Y Hospital)",
+          "destination": "San Fernando",
+          "scheduledTime": "2026-07-01T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -168,7 +280,7 @@
           "lineCode": "M-561",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
           "destination": "Jerez",
-          "scheduledTime": "2026-06-30T10:45:00.000Z",
+          "scheduledTime": "2026-07-01T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -177,15 +289,15 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-06-30T10:50:00.000Z",
+          "scheduledTime": "2026-07-01T10:50:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -205,7 +317,7 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-30T10:16:00.000Z",
+          "scheduledTime": "2026-07-01T10:16:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -214,15 +326,15 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Chiclana",
-          "scheduledTime": "2026-06-30T10:44:00.000Z",
+          "scheduledTime": "2026-07-01T10:44:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -242,7 +354,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-30T10:05:00.000Z",
+          "scheduledTime": "2026-07-01T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -251,7 +363,16 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-30T10:10:00.000Z",
+          "scheduledTime": "2026-07-01T10:10:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "163",
+          "lineCode": "M-960",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
+          "destination": "Chipiona",
+          "scheduledTime": "2026-07-01T10:21:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -260,7 +381,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-06-30T10:35:00.000Z",
+          "scheduledTime": "2026-07-01T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -269,7 +390,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-30T10:40:00.000Z",
+          "scheduledTime": "2026-07-01T10:40:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -278,7 +399,7 @@
           "lineCode": "M-031",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
           "destination": "Puerto Real",
-          "scheduledTime": "2026-06-30T10:51:00.000Z",
+          "scheduledTime": "2026-07-01T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -287,15 +408,15 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-06-30T11:00:00.000Z",
+          "scheduledTime": "2026-07-01T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -311,11 +432,11 @@
       "nucleus": "Granada",
       "services": [
         {
-          "lineId": "1077",
-          "lineCode": "0124",
-          "lineName": "Granada - Atarfe",
-          "destination": "Atarfe",
-          "scheduledTime": "2026-06-30T10:28:00.000Z",
+          "lineId": "991",
+          "lineCode": "0225",
+          "lineName": "Granada - P.Puente",
+          "destination": "Pinos Puente",
+          "scheduledTime": "2026-07-01T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -324,7 +445,16 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-06-30T11:08:00.000Z",
+          "scheduledTime": "2026-07-01T10:28:00.000Z",
+          "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "991",
+          "lineCode": "0225",
+          "lineName": "Granada - P.Puente",
+          "destination": "Pinos Puente",
+          "scheduledTime": "2026-07-01T11:06:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -333,15 +463,33 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-06-30T11:48:00.000Z",
+          "scheduledTime": "2026-07-01T11:08:00.000Z",
+          "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "1077",
+          "lineCode": "0124",
+          "lineName": "Granada - Atarfe",
+          "destination": "Atarfe",
+          "scheduledTime": "2026-07-01T11:48:00.000Z",
+          "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "991",
+          "lineCode": "0225",
+          "lineName": "Granada - P.Puente",
+          "destination": "Pinos Puente",
+          "scheduledTime": "2026-07-01T11:51:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T12:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T12:00:00.000Z"
       }
     },
     {
@@ -361,7 +509,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Granada",
-          "scheduledTime": "2026-06-30T10:39:00.000Z",
+          "scheduledTime": "2026-07-01T10:39:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -370,7 +518,7 @@
           "lineCode": "0318",
           "lineName": "Granada - Colomera",
           "destination": "Cerro Cauro",
-          "scheduledTime": "2026-06-30T10:41:00.000Z",
+          "scheduledTime": "2026-07-01T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -379,15 +527,15 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Parque del Cubillas",
-          "scheduledTime": "2026-06-30T11:30:00.000Z",
+          "scheduledTime": "2026-07-01T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T12:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T12:00:00.000Z"
       }
     },
     {
@@ -407,7 +555,7 @@
           "lineCode": "0241",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
           "destination": "Cijuela",
-          "scheduledTime": "2026-06-30T10:26:00.000Z",
+          "scheduledTime": "2026-07-01T10:26:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -416,7 +564,7 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-30T11:27:00.000Z",
+          "scheduledTime": "2026-07-01T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -425,15 +573,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-06-30T11:57:00.000Z",
+          "scheduledTime": "2026-07-01T11:57:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T12:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T12:00:00.000Z"
       }
     },
     {
@@ -453,15 +601,15 @@
           "lineCode": "0340",
           "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
           "destination": "Granada",
-          "scheduledTime": "2026-06-30T11:01:00.000Z",
+          "scheduledTime": "2026-07-01T11:01:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T12:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T12:00:00.000Z"
       }
     },
     {
@@ -475,11 +623,57 @@
       },
       "municipality": "Vegas del Genil",
       "nucleus": "Ambroz",
-      "services": [],
+      "services": [
+        {
+          "lineId": "1042",
+          "lineCode": "0154",
+          "lineName": "Granada-V. del Genil (Directo)",
+          "destination": "Granada",
+          "scheduledTime": "2026-07-01T10:00:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "1113",
+          "lineCode": "0150",
+          "lineName": "Granada - Cúllar V. - V. del Genil",
+          "destination": "El Ventorrillo",
+          "scheduledTime": "2026-07-01T10:01:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "1042",
+          "lineCode": "0154",
+          "lineName": "Granada-V. del Genil (Directo)",
+          "destination": "El Ventorrillo",
+          "scheduledTime": "2026-07-01T10:45:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "1042",
+          "lineCode": "0154",
+          "lineName": "Granada-V. del Genil (Directo)",
+          "destination": "Granada",
+          "scheduledTime": "2026-07-01T11:15:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "1113",
+          "lineCode": "0150",
+          "lineName": "Granada - Cúllar V. - V. del Genil",
+          "destination": "El Ventorrillo",
+          "scheduledTime": "2026-07-01T11:46:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T12:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T12:00:00.000Z"
       }
     },
     {
@@ -499,15 +693,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-30T10:11:00.000Z",
+          "scheduledTime": "2026-07-01T10:11:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T10:15:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T10:15:00.000Z"
       }
     },
     {
@@ -527,15 +721,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-30T10:08:00.000Z",
+          "scheduledTime": "2026-07-01T10:08:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T10:15:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T10:15:00.000Z"
       }
     },
     {
@@ -551,9 +745,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T10:15:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T10:15:00.000Z"
       }
     },
     {
@@ -573,15 +767,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-30T10:05:00.000Z",
+          "scheduledTime": "2026-07-01T10:05:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T10:15:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T10:15:00.000Z"
       }
     },
     {
@@ -601,15 +795,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-06-30T10:02:00.000Z",
+          "scheduledTime": "2026-07-01T10:02:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T10:15:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T10:15:00.000Z"
       }
     },
     {
@@ -625,9 +819,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -647,7 +841,7 @@
           "lineCode": "M-161",
           "lineName": "Barbate-Facinas-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-30T10:10:00.000Z",
+          "scheduledTime": "2026-07-01T10:10:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -656,15 +850,15 @@
           "lineCode": "M-150",
           "lineName": "Algeciras-Tarifa",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-30T10:45:00.000Z",
+          "scheduledTime": "2026-07-01T10:45:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -684,7 +878,7 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-30T10:30:00.000Z",
+          "scheduledTime": "2026-07-01T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -693,15 +887,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-30T10:30:00.000Z",
+          "scheduledTime": "2026-07-01T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -721,15 +915,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-06-30T10:03:00.000Z",
+          "scheduledTime": "2026-07-01T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -749,7 +943,7 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-06-30T10:45:00.000Z",
+          "scheduledTime": "2026-07-01T10:45:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -758,15 +952,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-06-30T11:00:00.000Z",
+          "scheduledTime": "2026-07-01T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -786,7 +980,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ADRA",
-          "scheduledTime": "2026-06-30T10:36:00.000Z",
+          "scheduledTime": "2026-07-01T10:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -795,7 +989,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-06-30T10:48:00.000Z",
+          "scheduledTime": "2026-07-01T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -804,15 +998,15 @@
           "lineCode": "M-384",
           "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
           "destination": "ADRA",
-          "scheduledTime": "2026-06-30T10:51:00.000Z",
+          "scheduledTime": "2026-07-01T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -828,9 +1022,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -846,9 +1040,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -864,9 +1058,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -882,9 +1076,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T11:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T11:00:00.000Z"
       }
     },
     {
@@ -900,9 +1094,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T12:30:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T12:30:00.000Z"
       }
     },
     {
@@ -916,11 +1110,84 @@
       },
       "municipality": "Torredelcampo",
       "nucleus": "Torredelcampo",
-      "services": [],
+      "services": [
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-07-01T10:20:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "287",
+          "lineCode": "M20-11",
+          "lineName": "Fuensanta de Martos - Jaén, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-01T10:38:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "283",
+          "lineCode": "M20-06",
+          "lineName": "Jaén - Córdoba (Ruta), 2024",
+          "destination": "Torredonjimeno",
+          "scheduledTime": "2026-07-01T10:50:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-01T11:13:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-07-01T11:20:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "281",
+          "lineCode": "M20-04",
+          "lineName": "Jaén - Alcaudete, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-01T11:43:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "288",
+          "lineCode": "M20-12",
+          "lineName": "Jaén - Escañuela, 2024",
+          "destination": "Escañuela",
+          "scheduledTime": "2026-07-01T11:55:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "285",
+          "lineCode": "M20-08",
+          "lineName": "Jaén - Lopera, 2024",
+          "destination": "Torredonjimeno",
+          "scheduledTime": "2026-07-01T12:20:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T12:30:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T12:30:00.000Z"
       }
     },
     {
@@ -934,11 +1201,84 @@
       },
       "municipality": "Torredonjimeno",
       "nucleus": "Torredonjimeno",
-      "services": [],
+      "services": [
+        {
+          "lineId": "287",
+          "lineCode": "M20-11",
+          "lineName": "Fuensanta de Martos - Jaén, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-01T10:25:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-07-01T10:33:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-01T11:00:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "283",
+          "lineCode": "M20-06",
+          "lineName": "Jaén - Córdoba (Ruta), 2024",
+          "destination": "Torredonjimeno",
+          "scheduledTime": "2026-07-01T11:03:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "281",
+          "lineCode": "M20-04",
+          "lineName": "Jaén - Alcaudete, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-01T11:30:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-07-01T11:33:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "288",
+          "lineCode": "M20-12",
+          "lineName": "Jaén - Escañuela, 2024",
+          "destination": "Escañuela",
+          "scheduledTime": "2026-07-01T12:08:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-01T12:25:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T12:30:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T12:30:00.000Z"
       }
     },
     {
@@ -952,11 +1292,102 @@
       },
       "municipality": "Mengibar",
       "nucleus": "Mengíbar",
-      "services": [],
+      "services": [
+        {
+          "lineId": "203",
+          "lineCode": "M04-8",
+          "lineName": "Linares - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-01T10:00:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "71",
+          "lineCode": "M16-1",
+          "lineName": "Santa Elena - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-01T10:05:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "73",
+          "lineCode": "M16-3",
+          "lineName": "Bailén - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-07-01T10:15:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "71",
+          "lineCode": "M16-1",
+          "lineName": "Santa Elena - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-07-01T10:40:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "203",
+          "lineCode": "M04-8",
+          "lineName": "Linares - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-07-01T11:00:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "71",
+          "lineCode": "M16-1",
+          "lineName": "Santa Elena - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-07-01T11:25:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "203",
+          "lineCode": "M04-8",
+          "lineName": "Linares - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-01T11:30:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "72",
+          "lineCode": "M16-2",
+          "lineName": "La Carolina - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-07-01T11:45:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "203",
+          "lineCode": "M04-8",
+          "lineName": "Linares - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-07-01T11:55:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "276",
+          "lineCode": "M15-7",
+          "lineName": "Jaén - Andújar - Marmolejo",
+          "destination": "Andújar",
+          "scheduledTime": "2026-07-01T12:25:00.000Z",
+          "direction": 1,
+          "stopType": 1
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T12:30:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T12:30:00.000Z"
       }
     },
     {
@@ -972,19 +1403,55 @@
       "nucleus": "Mancha Real",
       "services": [
         {
+          "lineId": "17",
+          "lineCode": "M1-9",
+          "lineName": "Mancha Real - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-01T10:30:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "17",
+          "lineCode": "M1-9",
+          "lineName": "Mancha Real - Jaén",
+          "destination": "Mancha Real",
+          "scheduledTime": "2026-07-01T10:55:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
           "lineId": "35",
           "lineCode": "M3-103",
           "lineName": "Úbeda - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-06-30T11:00:00.000Z",
+          "scheduledTime": "2026-07-01T11:00:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "17",
+          "lineCode": "M1-9",
+          "lineName": "Mancha Real - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-01T11:30:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "17",
+          "lineCode": "M1-9",
+          "lineName": "Mancha Real - Jaén",
+          "destination": "Mancha Real",
+          "scheduledTime": "2026-07-01T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T12:30:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T12:30:00.000Z"
       }
     },
     {
@@ -1000,9 +1467,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-07-01T02:39:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-02T02:39:00.000Z"
       }
     },
     {
@@ -1018,9 +1485,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-07-01T02:39:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-02T02:39:00.000Z"
       }
     },
     {
@@ -1036,9 +1503,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-07-01T02:39:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-02T02:39:00.000Z"
       }
     },
     {
@@ -1054,9 +1521,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-07-01T02:39:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-02T02:39:00.000Z"
       }
     },
     {
@@ -1072,9 +1539,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-07-01T02:39:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-02T02:39:00.000Z"
       }
     },
     {
@@ -1088,11 +1555,183 @@
       },
       "municipality": "LEPE",
       "nucleus": "LEPE",
-      "services": [],
+      "services": [
+        {
+          "lineId": "38",
+          "lineCode": "M-313",
+          "lineName": "Lepe-La Antilla",
+          "destination": "LA ANTILLA",
+          "scheduledTime": "2026-07-01T10:00:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "13",
+          "lineCode": "M-303",
+          "lineName": "Huelva-Corrales-Ayamonte",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-01T10:04:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-01T10:21:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "38",
+          "lineCode": "M-313",
+          "lineName": "Lepe-La Antilla",
+          "destination": "LEPE",
+          "scheduledTime": "2026-07-01T10:42:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "38",
+          "lineCode": "M-313",
+          "lineName": "Lepe-La Antilla",
+          "destination": "LA ANTILLA",
+          "scheduledTime": "2026-07-01T11:00:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "13",
+          "lineCode": "M-303",
+          "lineName": "Huelva-Corrales-Ayamonte",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-01T11:04:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-01T11:11:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "66",
+          "lineCode": "M-902",
+          "lineName": "Ayamonte-Huelva-Sevilla",
+          "destination": "AYAMONTE",
+          "scheduledTime": "2026-07-01T11:21:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-01T11:41:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "38",
+          "lineCode": "M-313",
+          "lineName": "Lepe-La Antilla",
+          "destination": "LEPE",
+          "scheduledTime": "2026-07-01T11:42:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-01T11:44:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "38",
+          "lineCode": "M-313",
+          "lineName": "Lepe-La Antilla",
+          "destination": "LA ANTILLA",
+          "scheduledTime": "2026-07-01T12:00:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "8",
+          "lineCode": "M-316",
+          "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
+          "destination": "VILLABLANCA",
+          "scheduledTime": "2026-07-01T12:36:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "38",
+          "lineCode": "M-313",
+          "lineName": "Lepe-La Antilla",
+          "destination": "LEPE",
+          "scheduledTime": "2026-07-01T12:42:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "38",
+          "lineCode": "M-313",
+          "lineName": "Lepe-La Antilla",
+          "destination": "LA ANTILLA",
+          "scheduledTime": "2026-07-01T13:00:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-01T13:15:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-01T13:21:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "38",
+          "lineCode": "M-313",
+          "lineName": "Lepe-La Antilla",
+          "destination": "LEPE",
+          "scheduledTime": "2026-07-01T13:42:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-01T13:44:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T14:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T14:00:00.000Z"
       }
     },
     {
@@ -1106,11 +1745,75 @@
       },
       "municipality": "ISLA CRISTINA",
       "nucleus": "ISLA CRISTINA",
-      "services": [],
+      "services": [
+        {
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-01T10:49:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-01T11:20:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-01T11:50:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-01T12:20:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-01T12:30:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-01T13:20:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-01T13:49:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T14:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T14:00:00.000Z"
       }
     },
     {
@@ -1124,11 +1827,147 @@
       },
       "municipality": "ALMONTE",
       "nucleus": "ALMONTE",
-      "services": [],
+      "services": [
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-07-01T10:03:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "75",
+          "lineCode": "M-911",
+          "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-07-01T10:14:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "ALMONTE",
+          "scheduledTime": "2026-07-01T10:48:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-07-01T11:03:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "60",
+          "lineCode": "M-417",
+          "lineName": "Paterna-Torre Higuera",
+          "destination": "BOLLULLOS PAR DEL CONDADO",
+          "scheduledTime": "2026-07-01T11:18:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "ALMONTE",
+          "scheduledTime": "2026-07-01T11:48:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-07-01T12:03:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "48",
+          "lineCode": "M-405",
+          "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
+          "destination": "BOLLULLOS PAR DEL CONDADO",
+          "scheduledTime": "2026-07-01T12:36:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "70",
+          "lineCode": "M-906",
+          "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
+          "destination": "ROCIANA DEL CONDADO",
+          "scheduledTime": "2026-07-01T12:43:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "ALMONTE",
+          "scheduledTime": "2026-07-01T12:48:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-07-01T13:03:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "60",
+          "lineCode": "M-417",
+          "lineName": "Paterna-Torre Higuera",
+          "destination": "BOLLULLOS PAR DEL CONDADO",
+          "scheduledTime": "2026-07-01T13:48:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "ALMONTE",
+          "scheduledTime": "2026-07-01T13:48:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "48",
+          "lineCode": "M-405",
+          "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-01T13:52:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "75",
+          "lineCode": "M-911",
+          "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
+          "destination": "HINOJOS",
+          "scheduledTime": "2026-07-01T13:58:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T14:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T14:00:00.000Z"
       }
     },
     {
@@ -1144,9 +1983,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T14:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T14:00:00.000Z"
       }
     },
     {
@@ -1162,9 +2001,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-06-30T06:29:26.910Z",
-        "startTime": "2026-06-30T10:00:00.000Z",
-        "endTime": "2026-06-30T14:00:00.000Z"
+        "requestedAt": "2026-07-01T06:33:17.530Z",
+        "startTime": "2026-07-01T10:00:00.000Z",
+        "endTime": "2026-07-01T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:20.188Z",
+    "generatedAt": "2026-07-01T06:33:09.905Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:20.188Z",
+    "generatedAt": "2026-07-01T06:33:09.905Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:20.188Z",
+    "generatedAt": "2026-07-01T06:33:09.905Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,
     "consortiumName": "Área de Granada",
-    "stopCount": 840
+    "stopCount": 841
   },
   "stops": [
     {
@@ -4146,6 +4146,21 @@
       "location": {
         "latitude": 37.159684354102,
         "longitude": -3.6958613991737366
+      }
+    },
+    {
+      "consortiumId": 3,
+      "stopId": "16109",
+      "stopCode": "16109",
+      "name": "Clavel 3",
+      "municipality": "Cúllar Vega",
+      "municipalityId": "18057",
+      "nucleus": "El Ventorrillo",
+      "nucleusId": "488",
+      "zone": "B",
+      "location": {
+        "latitude": 37.1594166,
+        "longitude": -3.6987118
       }
     },
     {

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:20.188Z",
+    "generatedAt": "2026-07-01T06:33:09.905Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:20.188Z",
+    "generatedAt": "2026-07-01T06:33:09.905Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:20.188Z",
+    "generatedAt": "2026-07-01T06:33:09.905Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:20.188Z",
+    "generatedAt": "2026-07-01T06:33:09.905Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:20.188Z",
+    "generatedAt": "2026-07-01T06:33:09.905Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:20.188Z",
+    "generatedAt": "2026-07-01T06:33:09.905Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-06-30T06:29:20.188Z",
+    "generatedAt": "2026-07-01T06:33:09.905Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [
@@ -50,7 +50,7 @@
         "shortName": "CTHU"
       }
     ],
-    "totalStops": 4052
+    "totalStops": 4053
   },
   "chunks": [
     {
@@ -69,7 +69,7 @@
       "id": "consortium-3",
       "consortiumId": 3,
       "path": "chunks/consortium-3.json",
-      "stopCount": 840
+      "stopCount": 841
     },
     {
       "id": "consortium-4",
@@ -14897,6 +14897,17 @@
       "stopId": "966",
       "stopCode": "966",
       "name": "Clavel 2",
+      "municipality": "Cúllar Vega",
+      "municipalityId": "18057",
+      "nucleus": "El Ventorrillo",
+      "nucleusId": "488",
+      "consortiumId": 3,
+      "chunkId": "consortium-3"
+    },
+    {
+      "stopId": "16109",
+      "stopCode": "16109",
+      "name": "Clavel 3",
       "municipality": "Cúllar Vega",
       "municipalityId": "18057",
       "nucleus": "El Ventorrillo",


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-07-01 06:34 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new stop to the stop directory and increased the total stop count.
  * Refreshed the latest service snapshot with updated departures and time ranges.

* **Bug Fixes**
  * Updated generated catalog and directory metadata across all consortium datasets to keep published data current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->