### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:31.372Z",
+    "generatedAt": "2026-07-13T08:17:53.297Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:35.600Z",
+    "generatedAt": "2026-07-13T08:17:56.785Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -17,11 +17,21 @@
       },
       "municipality": "DOS HERMANAS",
       "nucleus": "FUENTE DEL REY (Dos Hermanas) zonaC",
-      "services": [],
+      "services": [
+        {
+          "lineId": "242",
+          "lineCode": "1320",
+          "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-07-13T10:07:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -37,28 +47,37 @@
       "nucleus": "ESPARTINAS",
       "services": [
         {
-          "lineId": "295",
-          "lineCode": "1681",
-          "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-07-12T10:27:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
           "lineId": "284",
           "lineCode": "1666",
           "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-07-12T10:31:00.000Z",
+          "scheduledTime": "2026-07-13T10:31:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "295",
+          "lineCode": "1681",
+          "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-07-13T10:42:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "279",
+          "lineCode": "1661",
+          "lineName": "M-166 Sanlúcar la Mayor - Sevilla",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-07-13T10:48:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -72,11 +91,30 @@
       },
       "municipality": "SANTIPONCE",
       "nucleus": "SANTIPONCE",
-      "services": [],
+      "services": [
+        {
+          "lineId": "287",
+          "lineCode": "1720",
+          "lineName": "M-170A Santiponce - Sevilla",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-07-13T10:02:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "287",
+          "lineCode": "1720",
+          "lineName": "M-170A Santiponce - Sevilla",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-07-13T10:32:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -92,9 +130,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -114,7 +152,7 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-07-12T10:04:00.000Z",
+          "scheduledTime": "2026-07-13T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -123,15 +161,24 @@
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-07-12T10:04:00.000Z",
+          "scheduledTime": "2026-07-13T10:04:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "232",
+          "lineCode": "1100",
+          "lineName": "M-110 La Algaba - Sevilla",
+          "destination": "LA ALGABA",
+          "scheduledTime": "2026-07-13T10:34:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -151,24 +198,15 @@
           "lineCode": "M-560",
           "lineName": "Rota-Jerez De La Frontera",
           "destination": "Rota",
-          "scheduledTime": "2026-07-12T10:30:00.000Z",
+          "scheduledTime": "2026-07-13T10:00:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "32",
-          "lineCode": "M-560",
-          "lineName": "Rota-Jerez De La Frontera",
-          "destination": "Jerez",
-          "scheduledTime": "2026-07-12T11:00:00.000Z",
-          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -184,9 +222,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -202,11 +240,11 @@
       "nucleus": "Sanlúcar de Barrameda",
       "services": [
         {
-          "lineId": "163",
-          "lineCode": "M-960",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
+          "lineId": "225",
+          "lineCode": "M-967",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-07-12T10:05:00.000Z",
+          "scheduledTime": "2026-07-13T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -215,26 +253,26 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Jerez",
-          "scheduledTime": "2026-07-12T10:05:00.000Z",
+          "scheduledTime": "2026-07-13T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "230",
-          "lineCode": "M-965",
-          "lineName": "Chipiona-Sanlúcar De Barrameda (Sevilla/Utrera)",
-          "destination": "Sanlúcar de Barrameda",
-          "scheduledTime": "2026-07-12T10:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "230",
-          "lineCode": "M-965",
-          "lineName": "Chipiona-Sanlúcar De Barrameda (Sevilla/Utrera)",
+          "lineId": "225",
+          "lineCode": "M-967",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-07-12T10:11:00.000Z",
+          "scheduledTime": "2026-07-13T10:28:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "165",
+          "lineCode": "M-962",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-San Fernando (Por Puerto Real Y Hospital)",
+          "destination": "San Fernando",
+          "scheduledTime": "2026-07-13T10:35:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
@@ -242,15 +280,24 @@
           "lineCode": "M-561",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
           "destination": "Jerez",
-          "scheduledTime": "2026-07-12T10:45:00.000Z",
+          "scheduledTime": "2026-07-13T10:45:00.000Z",
           "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "167",
+          "lineCode": "M-964",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
+          "destination": "Chipiona",
+          "scheduledTime": "2026-07-13T10:50:00.000Z",
+          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -264,11 +311,30 @@
       },
       "municipality": "Chiclana",
       "nucleus": "Chiclana",
-      "services": [],
+      "services": [
+        {
+          "lineId": "26",
+          "lineCode": "M-230",
+          "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
+          "destination": "Hospital Pto. Real",
+          "scheduledTime": "2026-07-13T10:16:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "26",
+          "lineCode": "M-230",
+          "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
+          "destination": "Chiclana",
+          "scheduledTime": "2026-07-13T10:44:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -287,8 +353,17 @@
           "lineId": "6",
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
+          "destination": "Hospital Pto. Real",
+          "scheduledTime": "2026-07-13T10:05:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "6",
+          "lineCode": "M-030",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-07-12T10:10:00.000Z",
+          "scheduledTime": "2026-07-13T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -297,7 +372,25 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-07-12T10:21:00.000Z",
+          "scheduledTime": "2026-07-13T10:21:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "6",
+          "lineCode": "M-030",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
+          "destination": "Hospital Pto. Real",
+          "scheduledTime": "2026-07-13T10:35:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "6",
+          "lineCode": "M-030",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
+          "destination": "Cádiz",
+          "scheduledTime": "2026-07-13T10:40:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -306,24 +399,24 @@
           "lineCode": "M-031",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
           "destination": "Puerto Real",
-          "scheduledTime": "2026-07-12T10:31:00.000Z",
+          "scheduledTime": "2026-07-13T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "9",
-          "lineCode": "M-031",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
+          "lineId": "6",
+          "lineCode": "M-030",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-07-12T10:52:00.000Z",
+          "scheduledTime": "2026-07-13T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -343,24 +436,60 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-07-12T10:21:00.000Z",
+          "scheduledTime": "2026-07-13T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
         {
-          "lineId": "992",
-          "lineCode": "0226",
-          "lineName": "Granada - P.Puente - Zujaira",
-          "destination": "Zujaira",
-          "scheduledTime": "2026-07-12T11:49:00.000Z",
+          "lineId": "1077",
+          "lineCode": "0124",
+          "lineName": "Granada - Atarfe",
+          "destination": "Atarfe",
+          "scheduledTime": "2026-07-13T10:28:00.000Z",
+          "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "991",
+          "lineCode": "0225",
+          "lineName": "Granada - P.Puente",
+          "destination": "Pinos Puente",
+          "scheduledTime": "2026-07-13T11:06:00.000Z",
+          "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "1077",
+          "lineCode": "0124",
+          "lineName": "Granada - Atarfe",
+          "destination": "Atarfe",
+          "scheduledTime": "2026-07-13T11:08:00.000Z",
+          "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "1077",
+          "lineCode": "0124",
+          "lineName": "Granada - Atarfe",
+          "destination": "Atarfe",
+          "scheduledTime": "2026-07-13T11:48:00.000Z",
+          "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "991",
+          "lineCode": "0225",
+          "lineName": "Granada - P.Puente",
+          "destination": "Pinos Puente",
+          "scheduledTime": "2026-07-13T11:51:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T12:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T12:00:00.000Z"
       }
     },
     {
@@ -379,8 +508,17 @@
           "lineId": "1032",
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
-          "destination": "Centro Penitenciario de Albolote",
-          "scheduledTime": "2026-07-12T10:00:00.000Z",
+          "destination": "Granada",
+          "scheduledTime": "2026-07-13T10:39:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "710",
+          "lineCode": "0318",
+          "lineName": "Granada - Colomera",
+          "destination": "Cerro Cauro",
+          "scheduledTime": "2026-07-13T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -388,25 +526,16 @@
           "lineId": "1032",
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
-          "destination": "Granada",
-          "scheduledTime": "2026-07-12T10:54:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "1032",
-          "lineCode": "0117",
-          "lineName": "Granada - P.Cubillas",
-          "destination": "Centro Penitenciario de Albolote",
-          "scheduledTime": "2026-07-12T11:30:00.000Z",
+          "destination": "Parque del Cubillas",
+          "scheduledTime": "2026-07-13T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T12:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T12:00:00.000Z"
       }
     },
     {
@@ -422,19 +551,37 @@
       "nucleus": "Chauchina",
       "services": [
         {
+          "lineId": "868",
+          "lineCode": "0241",
+          "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
+          "destination": "Cijuela",
+          "scheduledTime": "2026-07-13T10:26:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
           "lineId": "1119",
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-07-12T11:27:00.000Z",
+          "scheduledTime": "2026-07-13T11:27:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "1119",
+          "lineCode": "0242",
+          "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
+          "destination": "Láchar",
+          "scheduledTime": "2026-07-13T11:57:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T12:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T12:00:00.000Z"
       }
     },
     {
@@ -448,11 +595,21 @@
       },
       "municipality": "Cijuela",
       "nucleus": "Cijuela",
-      "services": [],
+      "services": [
+        {
+          "lineId": "877",
+          "lineCode": "0340",
+          "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
+          "destination": "Granada",
+          "scheduledTime": "2026-07-13T11:01:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T12:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T12:00:00.000Z"
       }
     },
     {
@@ -472,7 +629,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-07-12T10:00:00.000Z",
+          "scheduledTime": "2026-07-13T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -481,7 +638,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-07-12T10:01:00.000Z",
+          "scheduledTime": "2026-07-13T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -490,7 +647,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-07-12T10:45:00.000Z",
+          "scheduledTime": "2026-07-13T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -499,7 +656,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-07-12T11:15:00.000Z",
+          "scheduledTime": "2026-07-13T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -508,15 +665,15 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-07-12T11:31:00.000Z",
+          "scheduledTime": "2026-07-13T11:46:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T12:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T12:00:00.000Z"
       }
     },
     {
@@ -530,11 +687,21 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [],
+      "services": [
+        {
+          "lineId": "99",
+          "lineCode": "M-250",
+          "lineName": "Málaga-Almogía",
+          "destination": "Málaga",
+          "scheduledTime": "2026-07-13T10:11:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T10:15:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T10:15:00.000Z"
       }
     },
     {
@@ -548,11 +715,21 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [],
+      "services": [
+        {
+          "lineId": "99",
+          "lineCode": "M-250",
+          "lineName": "Málaga-Almogía",
+          "destination": "Málaga",
+          "scheduledTime": "2026-07-13T10:08:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T10:15:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T10:15:00.000Z"
       }
     },
     {
@@ -568,9 +745,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T10:15:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T10:15:00.000Z"
       }
     },
     {
@@ -584,11 +761,21 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [],
+      "services": [
+        {
+          "lineId": "99",
+          "lineCode": "M-250",
+          "lineName": "Málaga-Almogía",
+          "destination": "Málaga",
+          "scheduledTime": "2026-07-13T10:05:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T10:15:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T10:15:00.000Z"
       }
     },
     {
@@ -602,11 +789,21 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [],
+      "services": [
+        {
+          "lineId": "99",
+          "lineCode": "M-250",
+          "lineName": "Málaga-Almogía",
+          "destination": "Málaga",
+          "scheduledTime": "2026-07-13T10:02:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T10:15:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T10:15:00.000Z"
       }
     },
     {
@@ -622,9 +819,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -644,15 +841,24 @@
           "lineCode": "M-161",
           "lineName": "Barbate-Facinas-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-07-12T10:10:00.000Z",
+          "scheduledTime": "2026-07-13T10:10:00.000Z",
           "direction": 1,
           "stopType": 0
+        },
+        {
+          "lineId": "7",
+          "lineCode": "M-150",
+          "lineName": "Algeciras-Tarifa",
+          "destination": "Algeciras",
+          "scheduledTime": "2026-07-13T10:45:00.000Z",
+          "direction": 2,
+          "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -671,25 +877,25 @@
           "lineId": "1",
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
-          "destination": "Algeciras",
-          "scheduledTime": "2026-07-12T10:30:00.000Z",
-          "direction": 1,
+          "destination": "Los Barrios",
+          "scheduledTime": "2026-07-13T10:30:00.000Z",
+          "direction": 2,
           "stopType": 0
         },
         {
           "lineId": "1",
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
-          "destination": "Los Barrios",
-          "scheduledTime": "2026-07-12T10:30:00.000Z",
-          "direction": 2,
+          "destination": "Algeciras",
+          "scheduledTime": "2026-07-13T10:30:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -709,15 +915,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-07-12T10:03:00.000Z",
+          "scheduledTime": "2026-07-13T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -737,17 +943,8 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-07-12T10:45:00.000Z",
+          "scheduledTime": "2026-07-13T10:45:00.000Z",
           "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "11",
-          "lineCode": "M-230",
-          "lineName": "La Línea-San Roque",
-          "destination": "La Línea de la Concepción",
-          "scheduledTime": "2026-07-12T10:45:00.000Z",
-          "direction": 2,
           "stopType": 1
         },
         {
@@ -755,15 +952,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-07-12T11:00:00.000Z",
+          "scheduledTime": "2026-07-13T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -782,16 +979,34 @@
           "lineId": "40",
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
+          "destination": "ADRA",
+          "scheduledTime": "2026-07-13T10:36:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "40",
+          "lineCode": "M-380",
+          "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-07-12T10:33:00.000Z",
+          "scheduledTime": "2026-07-13T10:48:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "48",
+          "lineCode": "M-384",
+          "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
+          "destination": "ADRA",
+          "scheduledTime": "2026-07-13T10:51:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -807,9 +1022,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -825,9 +1040,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -843,9 +1058,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -861,9 +1076,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T11:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T11:00:00.000Z"
       }
     },
     {
@@ -879,9 +1094,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T12:30:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T12:30:00.000Z"
       }
     },
     {
@@ -897,30 +1112,21 @@
       "nucleus": "Torredelcampo",
       "services": [
         {
-          "lineId": "289",
-          "lineCode": "M20-13",
-          "lineName": "Jaén - Jamilena - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-07-12T10:33:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
           "lineId": "278",
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-07-12T10:35:00.000Z",
+          "scheduledTime": "2026-07-13T10:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "283",
-          "lineCode": "M20-06",
-          "lineName": "Jaén - Córdoba (Ruta), 2024",
+          "lineId": "287",
+          "lineCode": "M20-11",
+          "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-12T10:41:00.000Z",
-          "direction": 2,
+          "scheduledTime": "2026-07-13T10:38:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
@@ -928,16 +1134,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-07-12T11:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "281",
-          "lineCode": "M20-04",
-          "lineName": "Jaén - Alcaudete, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-07-12T11:55:00.000Z",
+          "scheduledTime": "2026-07-13T10:50:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -946,15 +1143,51 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-12T12:28:00.000Z",
+          "scheduledTime": "2026-07-13T11:13:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-07-13T11:20:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "281",
+          "lineCode": "M20-04",
+          "lineName": "Jaén - Alcaudete, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-13T11:43:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "288",
+          "lineCode": "M20-12",
+          "lineName": "Jaén - Escañuela, 2024",
+          "destination": "Escañuela",
+          "scheduledTime": "2026-07-13T11:55:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "285",
+          "lineCode": "M20-08",
+          "lineName": "Jaén - Lopera, 2024",
+          "destination": "Torredonjimeno",
+          "scheduledTime": "2026-07-13T12:20:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T12:30:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T12:30:00.000Z"
       }
     },
     {
@@ -970,21 +1203,12 @@
       "nucleus": "Torredonjimeno",
       "services": [
         {
-          "lineId": "289",
-          "lineCode": "M20-13",
-          "lineName": "Jaén - Jamilena - Martos, 2024",
+          "lineId": "287",
+          "lineCode": "M20-11",
+          "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-12T10:15:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "283",
-          "lineCode": "M20-06",
-          "lineName": "Jaén - Córdoba (Ruta), 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-07-12T10:28:00.000Z",
-          "direction": 2,
+          "scheduledTime": "2026-07-13T10:25:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
@@ -992,8 +1216,17 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-07-12T10:48:00.000Z",
+          "scheduledTime": "2026-07-13T10:33:00.000Z",
           "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-13T11:00:00.000Z",
+          "direction": 2,
           "stopType": 0
         },
         {
@@ -1001,7 +1234,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-07-12T11:33:00.000Z",
+          "scheduledTime": "2026-07-13T11:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1009,8 +1242,26 @@
           "lineId": "281",
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-13T11:30:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-07-12T12:08:00.000Z",
+          "scheduledTime": "2026-07-13T11:33:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "288",
+          "lineCode": "M20-12",
+          "lineName": "Jaén - Escañuela, 2024",
+          "destination": "Escañuela",
+          "scheduledTime": "2026-07-13T12:08:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1019,15 +1270,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-12T12:15:00.000Z",
+          "scheduledTime": "2026-07-13T12:25:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T12:30:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T12:30:00.000Z"
       }
     },
     {
@@ -1046,16 +1297,97 @@
           "lineId": "203",
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-13T10:00:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "71",
+          "lineCode": "M16-1",
+          "lineName": "Santa Elena - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-13T10:05:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "73",
+          "lineCode": "M16-3",
+          "lineName": "Bailén - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-07-12T11:00:00.000Z",
+          "scheduledTime": "2026-07-13T10:15:00.000Z",
           "direction": 2,
           "stopType": 0
+        },
+        {
+          "lineId": "71",
+          "lineCode": "M16-1",
+          "lineName": "Santa Elena - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-07-13T10:40:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "203",
+          "lineCode": "M04-8",
+          "lineName": "Linares - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-07-13T11:00:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "71",
+          "lineCode": "M16-1",
+          "lineName": "Santa Elena - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-07-13T11:25:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "203",
+          "lineCode": "M04-8",
+          "lineName": "Linares - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-13T11:30:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "72",
+          "lineCode": "M16-2",
+          "lineName": "La Carolina - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-07-13T11:45:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "203",
+          "lineCode": "M04-8",
+          "lineName": "Linares - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-07-13T11:55:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "276",
+          "lineCode": "M15-7",
+          "lineName": "Jaén - Andújar - Marmolejo",
+          "destination": "Andújar",
+          "scheduledTime": "2026-07-13T12:25:00.000Z",
+          "direction": 1,
+          "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T12:30:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T12:30:00.000Z"
       }
     },
     {
@@ -1069,11 +1401,57 @@
       },
       "municipality": "Mancha Real",
       "nucleus": "Mancha Real",
-      "services": [],
+      "services": [
+        {
+          "lineId": "17",
+          "lineCode": "M1-9",
+          "lineName": "Mancha Real - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-13T10:30:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "17",
+          "lineCode": "M1-9",
+          "lineName": "Mancha Real - Jaén",
+          "destination": "Mancha Real",
+          "scheduledTime": "2026-07-13T10:55:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "35",
+          "lineCode": "M3-103",
+          "lineName": "Úbeda - Jaén",
+          "destination": "Mancha Real",
+          "scheduledTime": "2026-07-13T11:00:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "17",
+          "lineCode": "M1-9",
+          "lineName": "Mancha Real - Jaén",
+          "destination": "Jaén",
+          "scheduledTime": "2026-07-13T11:30:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "17",
+          "lineCode": "M1-9",
+          "lineName": "Mancha Real - Jaén",
+          "destination": "Mancha Real",
+          "scheduledTime": "2026-07-13T11:55:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T12:30:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T12:30:00.000Z"
       }
     },
     {
@@ -1089,9 +1467,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-13T02:39:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-14T02:39:00.000Z"
       }
     },
     {
@@ -1107,9 +1485,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-13T02:39:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-14T02:39:00.000Z"
       }
     },
     {
@@ -1125,9 +1503,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-13T02:39:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-14T02:39:00.000Z"
       }
     },
     {
@@ -1143,9 +1521,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-13T02:39:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-14T02:39:00.000Z"
       }
     },
     {
@@ -1161,9 +1539,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-13T02:39:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-14T02:39:00.000Z"
       }
     },
     {
@@ -1183,17 +1561,26 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-12T10:00:00.000Z",
+          "scheduledTime": "2026-07-13T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "76",
-          "lineCode": "M-912",
-          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "lineId": "13",
+          "lineCode": "M-303",
+          "lineName": "Huelva-Corrales-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-12T10:03:00.000Z",
+          "scheduledTime": "2026-07-13T10:04:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-13T10:21:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
@@ -1201,7 +1588,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-12T10:42:00.000Z",
+          "scheduledTime": "2026-07-13T10:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1210,16 +1597,43 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-12T11:00:00.000Z",
+          "scheduledTime": "2026-07-13T11:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "76",
-          "lineCode": "M-912",
-          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "lineId": "13",
+          "lineCode": "M-303",
+          "lineName": "Huelva-Corrales-Ayamonte",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-13T11:04:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-13T11:11:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "66",
+          "lineCode": "M-902",
+          "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-07-12T11:22:00.000Z",
+          "scheduledTime": "2026-07-13T11:21:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-13T11:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1228,7 +1642,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-12T11:42:00.000Z",
+          "scheduledTime": "2026-07-13T11:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1237,7 +1651,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-12T11:44:00.000Z",
+          "scheduledTime": "2026-07-13T11:44:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1246,7 +1660,16 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-12T12:00:00.000Z",
+          "scheduledTime": "2026-07-13T12:00:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "8",
+          "lineCode": "M-316",
+          "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
+          "destination": "VILLABLANCA",
+          "scheduledTime": "2026-07-13T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1255,7 +1678,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-12T12:42:00.000Z",
+          "scheduledTime": "2026-07-13T12:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1264,16 +1687,25 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-12T13:00:00.000Z",
+          "scheduledTime": "2026-07-13T13:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "5",
-          "lineCode": "M-310",
-          "lineName": "Huelva-Isla Cristina-Ayamonte",
-          "destination": "AYAMONTE",
-          "scheduledTime": "2026-07-12T13:38:00.000Z",
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-13T13:15:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-13T13:21:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1282,15 +1714,24 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-12T13:42:00.000Z",
+          "scheduledTime": "2026-07-13T13:42:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-13T13:44:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T14:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T14:00:00.000Z"
       }
     },
     {
@@ -1309,34 +1750,70 @@
           "lineId": "69",
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-07-12T11:20:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "76",
-          "lineCode": "M-912",
-          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
-          "destination": "AYAMONTE",
-          "scheduledTime": "2026-07-12T12:00:00.000Z",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-13T10:49:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "76",
-          "lineCode": "M-912",
-          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-12T13:20:00.000Z",
+          "scheduledTime": "2026-07-13T11:20:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-13T11:50:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-13T12:20:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "36",
+          "lineCode": "M-309",
+          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-13T12:30:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-13T13:20:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "69",
+          "lineCode": "M-905",
+          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
+          "destination": "ISLA CRISTINA",
+          "scheduledTime": "2026-07-13T13:49:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T14:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T14:00:00.000Z"
       }
     },
     {
@@ -1356,7 +1833,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-12T10:03:00.000Z",
+          "scheduledTime": "2026-07-13T10:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1365,7 +1842,7 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-12T10:14:00.000Z",
+          "scheduledTime": "2026-07-13T10:14:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1374,7 +1851,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-07-12T10:48:00.000Z",
+          "scheduledTime": "2026-07-13T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1383,53 +1860,8 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-12T11:03:00.000Z",
+          "scheduledTime": "2026-07-13T11:03:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "ALMONTE",
-          "scheduledTime": "2026-07-12T11:48:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-12T12:03:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "ALMONTE",
-          "scheduledTime": "2026-07-12T12:48:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-12T13:03:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "ALMONTE",
-          "scheduledTime": "2026-07-12T13:48:00.000Z",
-          "direction": 2,
           "stopType": 0
         },
         {
@@ -1437,7 +1869,88 @@
           "lineCode": "M-417",
           "lineName": "Paterna-Torre Higuera",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-07-12T13:48:00.000Z",
+          "scheduledTime": "2026-07-13T11:18:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "ALMONTE",
+          "scheduledTime": "2026-07-13T11:48:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-07-13T12:03:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "48",
+          "lineCode": "M-405",
+          "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
+          "destination": "BOLLULLOS PAR DEL CONDADO",
+          "scheduledTime": "2026-07-13T12:36:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "70",
+          "lineCode": "M-906",
+          "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
+          "destination": "ROCIANA DEL CONDADO",
+          "scheduledTime": "2026-07-13T12:43:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "ALMONTE",
+          "scheduledTime": "2026-07-13T12:48:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-07-13T13:03:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "60",
+          "lineCode": "M-417",
+          "lineName": "Paterna-Torre Higuera",
+          "destination": "BOLLULLOS PAR DEL CONDADO",
+          "scheduledTime": "2026-07-13T13:48:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "ALMONTE",
+          "scheduledTime": "2026-07-13T13:48:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "48",
+          "lineCode": "M-405",
+          "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-07-13T13:52:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1446,15 +1959,15 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "HINOJOS",
-          "scheduledTime": "2026-07-12T13:58:00.000Z",
+          "scheduledTime": "2026-07-13T13:58:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T14:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T14:00:00.000Z"
       }
     },
     {
@@ -1470,9 +1983,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T14:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T14:00:00.000Z"
       }
     },
     {
@@ -1488,9 +2001,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-12T07:29:35.600Z",
-        "startTime": "2026-07-12T10:00:00.000Z",
-        "endTime": "2026-07-12T14:00:00.000Z"
+        "requestedAt": "2026-07-13T08:17:56.785Z",
+        "startTime": "2026-07-13T10:00:00.000Z",
+        "endTime": "2026-07-13T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:27.059Z",
+    "generatedAt": "2026-07-13T08:17:50.181Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:27.059Z",
+    "generatedAt": "2026-07-13T08:17:50.181Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:27.059Z",
+    "generatedAt": "2026-07-13T08:17:50.181Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:27.059Z",
+    "generatedAt": "2026-07-13T08:17:50.181Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:27.059Z",
+    "generatedAt": "2026-07-13T08:17:50.181Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:27.059Z",
+    "generatedAt": "2026-07-13T08:17:50.181Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:27.059Z",
+    "generatedAt": "2026-07-13T08:17:50.181Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:27.059Z",
+    "generatedAt": "2026-07-13T08:17:50.181Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:27.059Z",
+    "generatedAt": "2026-07-13T08:17:50.181Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-12T07:29:27.059Z",
+    "generatedAt": "2026-07-13T08:17:50.181Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-07-13 08:18 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Refreshed transit service information across multiple areas, including scheduled departures, destinations, directions, and stop types.
  * Updated the latest service snapshot and query time ranges, including extended coverage for select services.
  * Refreshed catalog and stop-directory generation timestamps to reflect the latest data update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->