### PR TITLE
ci(actions): standardize repository automation

### DIFF
--- a/.agents/specs/2026-07-29-repository-automation.md
+++ b/.agents/specs/2026-07-29-repository-automation.md
@@ -1,0 +1,46 @@
+# Repository automation standardization
+
+## Request
+
+Audit the active workflows against `fastypest`, harden cache maintenance, add Dependabot automation, and open one PR without merging or deploying.
+
+## Evidence
+
+- Default branch: `main`.
+- Stack: npm, Angular, and GitHub Pages.
+- Existing workflows: CI, Pages deployment, daily snapshot refresh, and shell-based daily cache deletion.
+- The old cache command was not empty-safe and ran daily. Existing CI/deploy/snapshot files also contain mutable Action tags; that larger pinning migration is intentionally separate.
+
+## Decision
+
+- Replace cache deletion with a weekly, cache-key-independent API workflow and manual dry-run by default.
+- Add grouped weekly npm and GitHub Actions updates after a seven-day cooldown.
+- Auto-approve patch/minor updates and development-only majors without checkout. Production majors require a current approval from a reviewer with repository write permission.
+- Resolve the default branch dynamically, pin introduced Actions by immutable SHA, and use read-only defaults.
+- Keep Pages deployment and snapshot automation unchanged; no release workflow is added.
+
+## Acceptance
+
+- [x] Empty and concurrently deleted cache entries are safe.
+- [x] No privileged workflow executes pull-request-controlled code.
+- [x] External or stale approvals cannot unlock production majors.
+- [x] Existing CI, deployment, and snapshot behavior is preserved.
+- [x] No release, deployment, or publication is performed.
+
+## Validation
+
+The proposed YAML parsed successfully and the current workflows/package scripts were inspected. Pull-request CI remains the runtime gate.
+
+## Risks and rollback
+
+Auto-merge, branch protection, and an appropriately scoped automation token are required for writes. Existing mutable Action tags remain separate debt. Revert this PR to roll back; no runtime data requires recovery.
+
+## Delivery
+
+- Branch: `agent/chore-repository-automation`
+- Base: `main`
+- Merge/release/deploy/publish: not authorized
+
+## Status
+
+Implemented on the task branch; pull-request checks and repository settings remain to be verified.

--- a/.agents/specs/2026-07-29-repository-automation.md
+++ b/.agents/specs/2026-07-29-repository-automation.md
@@ -8,22 +8,24 @@ Audit the active workflows against `fastypest`, harden cache maintenance, add De
 
 - Default branch: `main`.
 - Stack: npm, Angular, and GitHub Pages.
-- Existing workflows: CI, Pages deployment, daily snapshot refresh, and shell-based daily cache deletion.
-- The old cache command was not empty-safe and ran daily. Existing CI/deploy/snapshot files also contain mutable Action tags; that larger pinning migration is intentionally separate.
+- Existing workflows cover CI, Pages deployment, daily snapshot refresh, and shell-based cache deletion.
+- Dependabot-triggered `pull_request_target` workflows receive a read-only token and no secrets, so privileged Dependabot automation must not depend on repository secrets.
 
 ## Decision
 
 - Replace cache deletion with a weekly, cache-key-independent API workflow and manual dry-run by default.
 - Add grouped weekly npm and GitHub Actions updates after a seven-day cooldown.
-- Auto-approve patch/minor updates and development-only majors without checkout. Production majors require a current approval from a reviewer with repository write permission.
-- Resolve the default branch dynamically, pin introduced Actions by immutable SHA, and use read-only defaults.
+- Use `pull_request` plus the repository-scoped `GITHUB_TOKEN` for Dependabot approval, labels, and auto-merge; no PR code is checked out.
+- Require a current write-permission maintainer approval for production majors, bound to the current head SHA.
+- Use the scheduled default-branch workflow and `GITHUB_TOKEN` for required-QA branch updates and auto-merge.
 - Keep Pages deployment and snapshot automation unchanged; no release workflow is added.
 
 ## Acceptance
 
 - [x] Empty and concurrently deleted cache entries are safe.
-- [x] No privileged workflow executes pull-request-controlled code.
+- [x] No privileged workflow checks out pull-request-controlled code.
 - [x] External or stale approvals cannot unlock production majors.
+- [x] No new repository secret or variable is required.
 - [x] Existing CI, deployment, and snapshot behavior is preserved.
 - [x] No release, deployment, or publication is performed.
 
@@ -31,9 +33,13 @@ Audit the active workflows against `fastypest`, harden cache maintenance, add De
 
 The proposed YAML parsed successfully and the current workflows/package scripts were inspected. Pull-request CI remains the runtime gate.
 
+## Repository settings
+
+Enable repository auto-merge and `Allow GitHub Actions to create and approve pull requests`. Required status checks must remain enforced on `main`.
+
 ## Risks and rollback
 
-Auto-merge, branch protection, and an appropriately scoped automation token are required for writes. Existing mutable Action tags remain separate debt. Revert this PR to roll back; no runtime data requires recovery.
+The workflows cannot approve or queue pull requests if the repository settings above are disabled. Existing mutable Action tags remain separate debt. Revert this PR to roll back; no runtime data requires recovery.
 
 ## Delivery
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "07:00"
+      timezone: "Europe/Madrid"
+    versioning-strategy: "increase-if-necessary"
+    rebase-strategy: "auto"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      production-minor-patch:
+        patterns: ["*"]
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      development-minor-patch:
+        patterns: ["*"]
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Madrid"
+    rebase-strategy: "auto"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps-actions)"
+    groups:
+      actions-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -19,46 +19,44 @@ concurrency:
 
 jobs:
   process:
+    name: Process approved Dependabot majors
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
-      pull-requests: read
-    env:
-      AUTOMATION_TOKEN: ${{ secrets.REPOSITORY_AUTOMATION_TOKEN || secrets.PAT_FINE }}
+      contents: write
+      pull-requests: write
     steps:
-      - name: Explain missing automation token
-        if: env.AUTOMATION_TOKEN == ''
-        run: echo "::notice title=Repository automation token missing::Configure REPOSITORY_AUTOMATION_TOKEN or PAT_FINE to enable branch updates and auto-merge."
-
       - name: Validate current approvals and enable auto-merge
-        if: env.AUTOMATION_TOKEN != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           DRY_RUN: ${{ inputs.dry_run || false }}
         with:
-          github-token: ${{ env.AUTOMATION_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const dryRun = process.env.DRY_RUN === 'true';
             const { owner, repo } = context.repo;
             const defaultBranch = context.payload.repository.default_branch;
-            const pulls = await github.paginate(github.rest.pulls.list, {
-              owner,
-              repo,
-              state: 'open',
-              per_page: 100,
-            });
-            const candidates = pulls.filter(
-              (pr) =>
-                pr.user?.login === 'dependabot[bot]' &&
-                pr.base.ref === defaultBranch &&
-                pr.head.repo?.full_name === `${owner}/${repo}` &&
-                pr.labels.some((label) => label.name === 'requires-manual-qa'),
+            const pullRequests = await github.paginate(
+              github.rest.pulls.list,
+              { owner, repo, state: 'open', per_page: 100 },
+            );
+
+            const candidates = pullRequests.filter(
+              (pullRequest) =>
+                pullRequest.user?.login === 'dependabot[bot]' &&
+                pullRequest.base.ref === defaultBranch &&
+                pullRequest.head.repo?.full_name === `${owner}/${repo}` &&
+                pullRequest.labels.some(
+                  (label) => label.name === 'requires-manual-qa',
+                ),
             );
 
             const permissionCache = new Map();
-            const canApprove = async (login) => {
-              if (permissionCache.has(login)) return permissionCache.get(login);
+            const hasWritePermission = async (login) => {
+              if (permissionCache.has(login)) {
+                return permissionCache.get(login);
+              }
+
               try {
                 const response =
                   await github.rest.repos.getCollaboratorPermissionLevel({
@@ -72,7 +70,10 @@ jobs:
                 permissionCache.set(login, allowed);
                 return allowed;
               } catch (error) {
-                if (error.status === 404) return false;
+                if (error.status === 404) {
+                  permissionCache.set(login, false);
+                  return false;
+                }
                 throw error;
               }
             };
@@ -95,6 +96,7 @@ jobs:
                   });
                   continue;
                 }
+
                 await github.rest.pulls.updateBranch({
                   owner,
                   repo,
@@ -113,7 +115,8 @@ jobs:
                 github.rest.pulls.listReviews,
                 { owner, repo, pull_number: candidate.number, per_page: 100 },
               );
-              const latestByUser = new Map();
+              const latestReviewByUser = new Map();
+
               for (const review of reviews) {
                 const login = review.user?.login;
                 const submittedAt = Date.parse(review.submitted_at ?? '');
@@ -124,9 +127,10 @@ jobs:
                 ) {
                   continue;
                 }
-                const previous = latestByUser.get(login);
+
+                const previous = latestReviewByUser.get(login);
                 if (!previous || submittedAt > previous.submittedAt) {
-                  latestByUser.set(login, {
+                  latestReviewByUser.set(login, {
                     state: review.state,
                     submittedAt,
                   });
@@ -135,11 +139,17 @@ jobs:
 
               let approved = false;
               let changesRequested = false;
-              for (const [login, review] of latestByUser) {
-                if (login.endsWith('[bot]') || !(await canApprove(login))) continue;
+              for (const [login, review] of latestReviewByUser) {
+                if (
+                  login.endsWith('[bot]') ||
+                  !(await hasWritePermission(login))
+                ) {
+                  continue;
+                }
                 approved ||= review.state === 'APPROVED';
                 changesRequested ||= review.state === 'CHANGES_REQUESTED';
               }
+
               if (!approved || changesRequested) {
                 results.push({
                   number: candidate.number,
@@ -150,6 +160,7 @@ jobs:
                 });
                 continue;
               }
+
               if (dryRun) {
                 results.push({
                   number: candidate.number,
@@ -171,18 +182,32 @@ jobs:
                 });
                 continue;
               }
+
               if (!verified.data.auto_merge) {
                 await github.graphql(
-                  `mutation($id: ID!, $head: GitObjectID!) {
-                    enablePullRequestAutoMerge(input: {
-                      pullRequestId: $id
-                      mergeMethod: SQUASH
-                      expectedHeadOid: $head
-                    }) { pullRequest { number } }
+                  `mutation EnableAutoMerge(
+                    $pullRequestId: ID!
+                    $expectedHeadOid: GitObjectID!
+                  ) {
+                    enablePullRequestAutoMerge(
+                      input: {
+                        pullRequestId: $pullRequestId
+                        mergeMethod: SQUASH
+                        expectedHeadOid: $expectedHeadOid
+                      }
+                    ) {
+                      pullRequest {
+                        number
+                      }
+                    }
                   }`,
-                  { id: verified.data.node_id, head: currentHeadSha },
+                  {
+                    pullRequestId: verified.data.node_id,
+                    expectedHeadOid: currentHeadSha,
+                  },
                 );
               }
+
               results.push({
                 number: candidate.number,
                 action: 'auto-merge-enabled',
@@ -192,14 +217,14 @@ jobs:
             await core.summary
               .addHeading('Required QA auto-merge')
               .addRaw(
-                results.length
-                  ? results
+                results.length === 0
+                  ? 'No eligible Dependabot pull requests found.'
+                  : results
                       .map(
                         (result) =>
                           `- #${result.number}: ${result.action}` +
                           `${result.reason ? ` — ${result.reason}` : ''}`,
                       )
-                      .join('\n')
-                  : 'No eligible Dependabot pull requests found.',
+                      .join('\n'),
               )
               .write();

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -1,0 +1,88 @@
+name: 🔄 Required QA auto-merge
+
+on:
+  schedule:
+    - cron: "0 8 * * 6"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report eligible pull requests without enabling auto-merge
+        required: true
+        default: true
+        type: boolean
+
+permissions: read-all
+concurrency:
+  group: required-qa-auto-merge
+  cancel-in-progress: false
+
+jobs:
+  process:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          DRY_RUN: ${{ inputs.dry_run || false }}
+        with:
+          script: |
+            const dryRun = process.env.DRY_RUN === 'true';
+            const { owner, repo } = context.repo;
+            const pulls = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 });
+            const candidates = pulls.filter((pr) =>
+              pr.user?.login === 'dependabot[bot]' &&
+              pr.base.ref === context.payload.repository.default_branch &&
+              pr.head.repo?.full_name === `${owner}/${repo}` &&
+              pr.labels.some((label) => label.name === 'requires-manual-qa'),
+            );
+            const permissionCache = new Map();
+            const canApprove = async (login) => {
+              if (permissionCache.has(login)) return permissionCache.get(login);
+              try {
+                const response = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username: login });
+                const allowed = ['admin', 'maintain', 'write'].includes(response.data.permission);
+                permissionCache.set(login, allowed);
+                return allowed;
+              } catch (error) {
+                if (error.status === 404) return false;
+                throw error;
+              }
+            };
+            const results = [];
+            for (const candidate of candidates) {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number: candidate.number, per_page: 100 });
+              const latest = new Map();
+              for (const review of reviews) {
+                const login = review.user?.login;
+                const submittedAt = Date.parse(review.submitted_at ?? '');
+                if (!login || !Number.isFinite(submittedAt)) continue;
+                const previous = latest.get(login);
+                if (!previous || submittedAt > previous.submittedAt) latest.set(login, { state: review.state, submittedAt });
+              }
+              let approved = false;
+              let changesRequested = false;
+              for (const [login, review] of latest) {
+                if (login.endsWith('[bot]') || !(await canApprove(login))) continue;
+                approved ||= review.state === 'APPROVED';
+                changesRequested ||= review.state === 'CHANGES_REQUESTED';
+              }
+              if (!approved || changesRequested) { results.push({ number: candidate.number, action: 'skipped' }); continue; }
+              if (dryRun) { results.push({ number: candidate.number, action: 'would-enable-auto-merge' }); continue; }
+              const current = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+              if (current.data.mergeable_state === 'behind') {
+                await github.rest.pulls.updateBranch({ owner, repo, pull_number: candidate.number, expected_head_sha: current.data.head.sha });
+              }
+              if (!current.data.auto_merge) {
+                await github.graphql(
+                  `mutation($id: ID!) { enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: SQUASH }) { pullRequest { number } } }`,
+                  { id: current.data.node_id },
+                );
+              }
+              results.push({ number: candidate.number, action: 'auto-merge-enabled' });
+            }
+            await core.summary.addHeading('Required QA auto-merge').addRaw(
+              results.length ? results.map((result) => `- #${result.number}: ${result.action}`).join('\n') : 'No eligible Dependabot pull requests found.',
+            ).write();

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -12,6 +12,7 @@ on:
         type: boolean
 
 permissions: read-all
+
 concurrency:
   group: required-qa-auto-merge
   cancel-in-progress: false
@@ -21,29 +22,53 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
+    env:
+      AUTOMATION_TOKEN: ${{ secrets.REPOSITORY_AUTOMATION_TOKEN || secrets.PAT_FINE }}
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - name: Explain missing automation token
+        if: env.AUTOMATION_TOKEN == ''
+        run: echo "::notice title=Repository automation token missing::Configure REPOSITORY_AUTOMATION_TOKEN or PAT_FINE to enable branch updates and auto-merge."
+
+      - name: Validate current approvals and enable auto-merge
+        if: env.AUTOMATION_TOKEN != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           DRY_RUN: ${{ inputs.dry_run || false }}
         with:
+          github-token: ${{ env.AUTOMATION_TOKEN }}
           script: |
             const dryRun = process.env.DRY_RUN === 'true';
             const { owner, repo } = context.repo;
-            const pulls = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 });
-            const candidates = pulls.filter((pr) =>
-              pr.user?.login === 'dependabot[bot]' &&
-              pr.base.ref === context.payload.repository.default_branch &&
-              pr.head.repo?.full_name === `${owner}/${repo}` &&
-              pr.labels.some((label) => label.name === 'requires-manual-qa'),
+            const defaultBranch = context.payload.repository.default_branch;
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const candidates = pulls.filter(
+              (pr) =>
+                pr.user?.login === 'dependabot[bot]' &&
+                pr.base.ref === defaultBranch &&
+                pr.head.repo?.full_name === `${owner}/${repo}` &&
+                pr.labels.some((label) => label.name === 'requires-manual-qa'),
             );
+
             const permissionCache = new Map();
             const canApprove = async (login) => {
               if (permissionCache.has(login)) return permissionCache.get(login);
               try {
-                const response = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username: login });
-                const allowed = ['admin', 'maintain', 'write'].includes(response.data.permission);
+                const response =
+                  await github.rest.repos.getCollaboratorPermissionLevel({
+                    owner,
+                    repo,
+                    username: login,
+                  });
+                const allowed = ['admin', 'maintain', 'write'].includes(
+                  response.data.permission,
+                );
                 permissionCache.set(login, allowed);
                 return allowed;
               } catch (error) {
@@ -51,38 +76,130 @@ jobs:
                 throw error;
               }
             };
+
             const results = [];
             for (const candidate of candidates) {
-              const reviews = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number: candidate.number, per_page: 100 });
-              const latest = new Map();
+              const current = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: candidate.number,
+              });
+              const currentHeadSha = current.data.head.sha;
+
+              if (current.data.mergeable_state === 'behind') {
+                if (dryRun) {
+                  results.push({
+                    number: candidate.number,
+                    action: 'would-update-branch',
+                    reason: 'fresh approval required after the update',
+                  });
+                  continue;
+                }
+                await github.rest.pulls.updateBranch({
+                  owner,
+                  repo,
+                  pull_number: candidate.number,
+                  expected_head_sha: currentHeadSha,
+                });
+                results.push({
+                  number: candidate.number,
+                  action: 'branch-update-requested',
+                  reason: 'fresh approval required for the new head commit',
+                });
+                continue;
+              }
+
+              const reviews = await github.paginate(
+                github.rest.pulls.listReviews,
+                { owner, repo, pull_number: candidate.number, per_page: 100 },
+              );
+              const latestByUser = new Map();
               for (const review of reviews) {
                 const login = review.user?.login;
                 const submittedAt = Date.parse(review.submitted_at ?? '');
-                if (!login || !Number.isFinite(submittedAt)) continue;
-                const previous = latest.get(login);
-                if (!previous || submittedAt > previous.submittedAt) latest.set(login, { state: review.state, submittedAt });
+                if (
+                  !login ||
+                  !Number.isFinite(submittedAt) ||
+                  review.commit_id !== currentHeadSha
+                ) {
+                  continue;
+                }
+                const previous = latestByUser.get(login);
+                if (!previous || submittedAt > previous.submittedAt) {
+                  latestByUser.set(login, {
+                    state: review.state,
+                    submittedAt,
+                  });
+                }
               }
+
               let approved = false;
               let changesRequested = false;
-              for (const [login, review] of latest) {
+              for (const [login, review] of latestByUser) {
                 if (login.endsWith('[bot]') || !(await canApprove(login))) continue;
                 approved ||= review.state === 'APPROVED';
                 changesRequested ||= review.state === 'CHANGES_REQUESTED';
               }
-              if (!approved || changesRequested) { results.push({ number: candidate.number, action: 'skipped' }); continue; }
-              if (dryRun) { results.push({ number: candidate.number, action: 'would-enable-auto-merge' }); continue; }
-              const current = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
-              if (current.data.mergeable_state === 'behind') {
-                await github.rest.pulls.updateBranch({ owner, repo, pull_number: candidate.number, expected_head_sha: current.data.head.sha });
+              if (!approved || changesRequested) {
+                results.push({
+                  number: candidate.number,
+                  action: 'skipped',
+                  reason: changesRequested
+                    ? 'current maintainer review requests changes'
+                    : 'no maintainer approval for the current head commit',
+                });
+                continue;
               }
-              if (!current.data.auto_merge) {
+              if (dryRun) {
+                results.push({
+                  number: candidate.number,
+                  action: 'would-enable-auto-merge',
+                });
+                continue;
+              }
+
+              const verified = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: candidate.number,
+              });
+              if (verified.data.head.sha !== currentHeadSha) {
+                results.push({
+                  number: candidate.number,
+                  action: 'skipped',
+                  reason: 'head commit changed during validation',
+                });
+                continue;
+              }
+              if (!verified.data.auto_merge) {
                 await github.graphql(
-                  `mutation($id: ID!) { enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: SQUASH }) { pullRequest { number } } }`,
-                  { id: current.data.node_id },
+                  `mutation($id: ID!, $head: GitObjectID!) {
+                    enablePullRequestAutoMerge(input: {
+                      pullRequestId: $id
+                      mergeMethod: SQUASH
+                      expectedHeadOid: $head
+                    }) { pullRequest { number } }
+                  }`,
+                  { id: verified.data.node_id, head: currentHeadSha },
                 );
               }
-              results.push({ number: candidate.number, action: 'auto-merge-enabled' });
+              results.push({
+                number: candidate.number,
+                action: 'auto-merge-enabled',
+              });
             }
-            await core.summary.addHeading('Required QA auto-merge').addRaw(
-              results.length ? results.map((result) => `- #${result.number}: ${result.action}`).join('\n') : 'No eligible Dependabot pull requests found.',
-            ).write();
+
+            await core.summary
+              .addHeading('Required QA auto-merge')
+              .addRaw(
+                results.length
+                  ? results
+                      .map(
+                        (result) =>
+                          `- #${result.number}: ${result.action}` +
+                          `${result.reason ? ` — ${result.reason}` : ''}`,
+                      )
+                      .join('\n')
+                  : 'No eligible Dependabot pull requests found.',
+              )
+              .write();

--- a/.github/workflows/delete-cache.workflow.yml
+++ b/.github/workflows/delete-cache.workflow.yml
@@ -1,45 +1,78 @@
-name: 🗑️ Delete old cache
-
-permissions:
-  actions: write
-  contents: read
+name: 🗑️ Cache maintenance
 
 on:
+  schedule:
+    - cron: "17 3 * * 0"
   workflow_dispatch:
     inputs:
-      expired-days:
-        description: "Clear cache that has not been used for x days"
-        default: "7"
+      stale_days:
+        description: Delete caches unused for this many days
         required: true
-  schedule:
-    - cron: "0 0 * * *"
+        default: "7"
+        type: string
+      dry_run:
+        description: Report matching caches without deleting them
+        required: true
+        default: true
+        type: boolean
+
+permissions: read-all
+concurrency:
+  group: cache-maintenance
+  cancel-in-progress: false
 
 jobs:
-  delete-cache:
-    if: github.actor == github.repository_owner || github.actor == 'github-actions'
+  cleanup:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
     steps:
-      - name: 🕐 Calculate ${{ inputs.expired-days || 7 }} days ago
-        id: subtract-days
-        run: echo "date=$(date -u -d '${{ inputs.expired-days || 7 }} days ago' +%Y-%m-%dT%H:%M:%SZ%z)" >> $GITHUB_OUTPUT
-
-      - name: 🧹 Delete old cache
-        id: delete-old-cache
+      - name: Inspect and delete stale caches
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${GITHUB_REPOSITORY}/actions/caches \
-            -q '.actions_caches[]
-                | { id, last_accessed_at }
-                | select(.last_accessed_at <= "'"${{ steps.subtract-days.outputs.date }}"'")
-                | {id}
-                | .[]' \
-            --paginate | xargs -I {} \
-          gh api \
-            --method DELETE \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${GITHUB_REPOSITORY}/actions/caches/{}
+          STALE_DAYS: ${{ inputs.stale_days || '7' }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
+        with:
+          script: |
+            const staleDays = Number.parseInt(process.env.STALE_DAYS, 10);
+            if (!Number.isInteger(staleDays) || staleDays < 1 || staleDays > 90) {
+              core.setFailed('stale_days must be an integer between 1 and 90');
+              return;
+            }
+            const dryRun = process.env.DRY_RUN === 'true';
+            const cutoff = Date.now() - staleDays * 86400000;
+            const { owner, repo } = context.repo;
+            const caches = await github.paginate(
+              'GET /repos/{owner}/{repo}/actions/caches',
+              { owner, repo, per_page: 100 },
+              (response) => response.data.actions_caches ?? [],
+            );
+            const stale = caches.filter((cache) => {
+              const lastAccessedAt = Date.parse(cache.last_accessed_at);
+              return Number.isFinite(lastAccessedAt) && lastAccessedAt <= cutoff;
+            });
+            let deleted = 0;
+            for (const cache of stale) {
+              core.info(`${dryRun ? 'Would delete' : 'Deleting'} ${cache.id} (${cache.key})`);
+              if (dryRun) continue;
+              try {
+                await github.request(
+                  'DELETE /repos/{owner}/{repo}/actions/caches/{cache_id}',
+                  { owner, repo, cache_id: cache.id },
+                );
+                deleted += 1;
+              } catch (error) {
+                if (error.status === 404) continue;
+                throw error;
+              }
+            }
+            await core.summary.addHeading('Actions cache maintenance').addTable([
+              [{ data: 'Metric', header: true }, { data: 'Value', header: true }],
+              ['Inspected', String(caches.length)],
+              ['Matched', String(stale.length)],
+              ['Deleted', String(deleted)],
+              ['Dry run', String(dryRun)],
+              ['Threshold', `${staleDays} days`],
+            ]).write();

--- a/.github/workflows/delete-cache.workflow.yml
+++ b/.github/workflows/delete-cache.workflow.yml
@@ -17,12 +17,14 @@ on:
         type: boolean
 
 permissions: read-all
+
 concurrency:
   group: cache-maintenance
   cancel-in-progress: false
 
 jobs:
   cleanup:
+    name: 🧹 Delete stale Actions caches
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -36,11 +38,13 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run || false }}
         with:
           script: |
-            const staleDays = Number.parseInt(process.env.STALE_DAYS, 10);
-            if (!Number.isInteger(staleDays) || staleDays < 1 || staleDays > 90) {
+            const staleDaysInput = process.env.STALE_DAYS ?? '';
+            if (!/^(?:[1-9]|[1-8]\d|90)$/.test(staleDaysInput)) {
               core.setFailed('stale_days must be an integer between 1 and 90');
               return;
             }
+
+            const staleDays = Number(staleDaysInput);
             const dryRun = process.env.DRY_RUN === 'true';
             const cutoff = Date.now() - staleDays * 86400000;
             const { owner, repo } = context.repo;
@@ -49,14 +53,18 @@ jobs:
               { owner, repo, per_page: 100 },
               (response) => response.data.actions_caches ?? [],
             );
-            const stale = caches.filter((cache) => {
+            const staleCaches = caches.filter((cache) => {
               const lastAccessedAt = Date.parse(cache.last_accessed_at);
               return Number.isFinite(lastAccessedAt) && lastAccessedAt <= cutoff;
             });
+
             let deleted = 0;
-            for (const cache of stale) {
-              core.info(`${dryRun ? 'Would delete' : 'Deleting'} ${cache.id} (${cache.key})`);
+            for (const cache of staleCaches) {
+              core.info(
+                `${dryRun ? 'Would delete' : 'Deleting'} ${cache.id} (${cache.key})`,
+              );
               if (dryRun) continue;
+
               try {
                 await github.request(
                   'DELETE /repos/{owner}/{repo}/actions/caches/{cache_id}',
@@ -68,11 +76,18 @@ jobs:
                 throw error;
               }
             }
-            await core.summary.addHeading('Actions cache maintenance').addTable([
-              [{ data: 'Metric', header: true }, { data: 'Value', header: true }],
-              ['Inspected', String(caches.length)],
-              ['Matched', String(stale.length)],
-              ['Deleted', String(deleted)],
-              ['Dry run', String(dryRun)],
-              ['Threshold', `${staleDays} days`],
-            ]).write();
+
+            await core.summary
+              .addHeading('Actions cache maintenance')
+              .addTable([
+                [
+                  { data: 'Metric', header: true },
+                  { data: 'Value', header: true },
+                ],
+                ['Repository caches inspected', String(caches.length)],
+                ['Caches older than threshold', String(staleCaches.length)],
+                ['Caches deleted', String(deleted)],
+                ['Dry run', String(dryRun)],
+                ['Threshold', `${staleDays} days`],
+              ])
+              .write();

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -41,7 +41,7 @@ jobs:
             version-update:semver-patch|version-update:semver-minor) eligible=true ;;
             version-update:semver-major)
               if [ "$DEPENDENCY_TYPE" = "direct:development" ]; then eligible=true; fi
-              if [ "$DEPENDENDENCY_TYPE" = "direct:production" ]; then manual=true; fi
+              if [ "$DEPENDENCY_TYPE" = "direct:production" ]; then manual=true; fi
               ;;
           esac
           echo "eligible=$eligible" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -52,7 +52,7 @@ jobs:
             version-update:semver-major)
               if [ "$DEPENDENCY_TYPE" = "direct:development" ]; then
                 eligible=true
-              elif [ "$DEPENDENDENCY_TYPE" = "direct:production" ]; then
+              elif [ "$DEPENDENCY_TYPE" = "direct:production" ]; then
                 requires_manual_qa=true
               fi
               ;;

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -1,0 +1,65 @@
+name: 🤖 Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions: read-all
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependabot:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    env:
+      AUTOMATION_TOKEN: ${{ secrets.REPOSITORY_AUTOMATION_TOKEN || secrets.PAT_FINE }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ github.token }}
+      - id: policy
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
+        run: |
+          eligible=false
+          manual=false
+          case "$UPDATE_TYPE" in
+            version-update:semver-patch|version-update:semver-minor) eligible=true ;;
+            version-update:semver-major)
+              if [ "$DEPENDENCY_TYPE" = "direct:development" ]; then eligible=true; fi
+              if [ "$DEPENDENDENCY_TYPE" = "direct:production" ]; then manual=true; fi
+              ;;
+          esac
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+          echo "manual=$manual" >> "$GITHUB_OUTPUT"
+      - name: Explain missing token
+        if: env.AUTOMATION_TOKEN == ''
+        run: echo "::notice title=Repository automation token missing::Configure REPOSITORY_AUTOMATION_TOKEN or PAT_FINE with Contents, Issues and Pull requests write access."
+      - name: Approve and queue eligible update
+        if: env.AUTOMATION_TOKEN != '' && steps.policy.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ env.AUTOMATION_TOKEN }}
+        run: |
+          gh pr review "$PR_URL" --approve --body "Approved automatically by the repository dependency policy."
+          gh pr merge "$PR_URL" --auto --squash --match-head-commit "$HEAD_SHA"
+      - name: Mark production major for manual QA
+        if: env.AUTOMATION_TOKEN != '' && steps.policy.outputs.manual == 'true'
+        env:
+          GH_TOKEN: ${{ env.AUTOMATION_TOKEN }}
+        run: |
+          gh label create "requires-manual-qa" --color "B60205" --description "Requires explicit maintainer approval before auto-merge" --force
+          gh pr edit "$PR_URL" --add-label "requires-manual-qa"

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -1,16 +1,21 @@
 name: 🤖 Dependabot auto-merge
 
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize]
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 permissions: read-all
+
 concurrency:
   group: dependabot-auto-merge-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   dependabot:
+    name: Validate and queue eligible updates
     if: >-
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
@@ -18,48 +23,70 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
-      issues: read
-      pull-requests: read
+      contents: write
+      issues: write
+      pull-requests: write
     env:
-      AUTOMATION_TOKEN: ${{ secrets.REPOSITORY_AUTOMATION_TOKEN || secrets.PAT_FINE }}
       PR_URL: ${{ github.event.pull_request.html_url }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
-      - id: metadata
+      - name: Read Dependabot metadata
+        id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ github.token }}
-      - id: policy
+
+      - name: Classify update policy
+        id: policy
         env:
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
           DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
         run: |
           eligible=false
-          manual=false
+          requires_manual_qa=false
+
           case "$UPDATE_TYPE" in
-            version-update:semver-patch|version-update:semver-minor) eligible=true ;;
+            version-update:semver-patch|version-update:semver-minor)
+              eligible=true
+              ;;
             version-update:semver-major)
-              if [ "$DEPENDENCY_TYPE" = "direct:development" ]; then eligible=true; fi
-              if [ "$DEPENDENCY_TYPE" = "direct:production" ]; then manual=true; fi
+              if [ "$DEPENDENCY_TYPE" = "direct:development" ]; then
+                eligible=true
+              elif [ "$DEPENDENDENCY_TYPE" = "direct:production" ]; then
+                requires_manual_qa=true
+              fi
               ;;
           esac
+
           echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
-          echo "manual=$manual" >> "$GITHUB_OUTPUT"
-      - name: Explain missing token
-        if: env.AUTOMATION_TOKEN == ''
-        run: echo "::notice title=Repository automation token missing::Configure REPOSITORY_AUTOMATION_TOKEN or PAT_FINE with Contents, Issues and Pull requests write access."
-      - name: Approve and queue eligible update
-        if: env.AUTOMATION_TOKEN != '' && steps.policy.outputs.eligible == 'true'
+          echo "requires_manual_qa=$requires_manual_qa" >> "$GITHUB_OUTPUT"
+
+      - name: Approve eligible update
+        if: steps.policy.outputs.eligible == 'true'
         env:
-          GH_TOKEN: ${{ env.AUTOMATION_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr review "$PR_URL" --approve --body "Approved automatically by the repository dependency policy."
-          gh pr merge "$PR_URL" --auto --squash --match-head-commit "$HEAD_SHA"
+          gh pr review "$PR_URL" \
+            --approve \
+            --body "Approved automatically: patch/minor update, or a development-only major update."
+
+      - name: Enable squash auto-merge
+        if: steps.policy.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr merge "$PR_URL" \
+            --auto \
+            --squash \
+            --match-head-commit "$HEAD_SHA"
+
       - name: Mark production major for manual QA
-        if: env.AUTOMATION_TOKEN != '' && steps.policy.outputs.manual == 'true'
+        if: steps.policy.outputs.requires_manual_qa == 'true'
         env:
-          GH_TOKEN: ${{ env.AUTOMATION_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          gh label create "requires-manual-qa" --color "B60205" --description "Requires explicit maintainer approval before auto-merge" --force
+          gh label create "requires-manual-qa" \
+            --color "B60205" \
+            --description "Requires explicit maintainer approval before auto-merge" \
+            --force
           gh pr edit "$PR_URL" --add-label "requires-manual-qa"


### PR DESCRIPTION
## What

- Replace shell-specific cache cleanup with a generic weekly API workflow and manual dry-run.
- Add grouped weekly npm and GitHub Actions updates.
- Add safe Dependabot auto-merge and maintainer-gated production majors.

## Scope and security

Existing CI, Pages deployment, and daily snapshot workflows remain unchanged. Dependabot automation uses the repository-scoped `GITHUB_TOKEN` on `pull_request`, does not check out PR code, and pins introduced Actions by full SHA. Required-QA approvals are bound to the current head SHA.

## Required repository settings

- Enable **Allow auto-merge**.
- Under **Settings → Actions → General → Workflow permissions**, enable **Allow GitHub Actions to create and approve pull requests**.
- Keep required status checks enforced on `main`.

No new secret or repository variable is required.

## Validation

Proposed YAML parsed successfully. No deployment, release, merge, or publication was performed.

## Rollback

Revert this PR to restore the previous automation.