### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,
@@ -93,7 +93,7 @@
         "NEX Continental Holdings",
         "S.L.U."
       ],
-      "hasNews": false,
+      "hasNews": true,
       "concession": null,
       "notes": null,
       "modeNotes": null,
@@ -268,7 +268,7 @@
         "NEX Continental Holdings",
         "S.L.U."
       ],
-      "hasNews": false,
+      "hasNews": true,
       "concession": null,
       "notes": null,
       "modeNotes": null,
@@ -1067,7 +1067,7 @@
         "NEX Continental Holdings",
         "S.L.U."
       ],
-      "hasNews": false,
+      "hasNews": true,
       "concession": null,
       "notes": null,
       "modeNotes": null,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,
@@ -956,31 +956,6 @@
       "inboundPath": []
     },
     {
-      "id": "288",
-      "code": "M-269",
-      "name": "Las Pedrizas-Antequera",
-      "mode": "Autobús",
-      "modeId": "1",
-      "operators": [
-        "Automóviles Mérida",
-        "S.L."
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "215",
       "code": "R-2",
       "name": "Los Delgado-Centro Comercial-Lo Cea-Benagalbón",
@@ -1806,6 +1781,31 @@
       "id": "325",
       "code": "M-363",
       "name": "Málaga-Torre de Mar-Hospital Vélez-Torrox",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Nex Continental Holdings",
+        "S.L.U."
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "334",
+      "code": "M-380",
+      "name": "Málaga-Torre del Mar Directo (desde el 30 de julio)",
       "mode": "Autobús",
       "modeId": "1",
       "operators": [

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:06.233Z",
+    "generatedAt": "2026-07-30T07:33:55.997Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:09.850Z",
+    "generatedAt": "2026-07-30T07:33:59.824Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -23,15 +23,15 @@
           "lineCode": "1320",
           "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-07-28T10:07:00.000Z",
+          "scheduledTime": "2026-07-30T10:07:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -51,7 +51,7 @@
           "lineCode": "1666",
           "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-07-28T10:31:00.000Z",
+          "scheduledTime": "2026-07-30T10:31:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -60,7 +60,7 @@
           "lineCode": "1681",
           "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-07-28T10:42:00.000Z",
+          "scheduledTime": "2026-07-30T10:42:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -69,15 +69,15 @@
           "lineCode": "1661",
           "lineName": "M-166 Sanlúcar la Mayor - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-07-28T10:48:00.000Z",
+          "scheduledTime": "2026-07-30T10:48:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -97,7 +97,7 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-07-28T10:02:00.000Z",
+          "scheduledTime": "2026-07-30T10:02:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -106,15 +106,15 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-07-28T10:32:00.000Z",
+          "scheduledTime": "2026-07-30T10:32:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -130,9 +130,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -152,7 +152,7 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-07-28T10:04:00.000Z",
+          "scheduledTime": "2026-07-30T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -161,7 +161,7 @@
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-07-28T10:04:00.000Z",
+          "scheduledTime": "2026-07-30T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -170,15 +170,15 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-07-28T10:34:00.000Z",
+          "scheduledTime": "2026-07-30T10:34:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -198,15 +198,15 @@
           "lineCode": "M-560",
           "lineName": "Rota-Jerez De La Frontera",
           "destination": "Rota",
-          "scheduledTime": "2026-07-28T10:00:00.000Z",
+          "scheduledTime": "2026-07-30T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -222,9 +222,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -244,7 +244,7 @@
           "lineCode": "M-967",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-07-28T10:05:00.000Z",
+          "scheduledTime": "2026-07-30T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -253,7 +253,7 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Jerez",
-          "scheduledTime": "2026-07-28T10:05:00.000Z",
+          "scheduledTime": "2026-07-30T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -262,7 +262,7 @@
           "lineCode": "M-967",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-07-28T10:28:00.000Z",
+          "scheduledTime": "2026-07-30T10:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -271,7 +271,7 @@
           "lineCode": "M-962",
           "lineName": "Chipiona-Sanlúcar De Barrameda-San Fernando (Por Puerto Real Y Hospital)",
           "destination": "San Fernando",
-          "scheduledTime": "2026-07-28T10:35:00.000Z",
+          "scheduledTime": "2026-07-30T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -280,7 +280,7 @@
           "lineCode": "M-561",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
           "destination": "Jerez",
-          "scheduledTime": "2026-07-28T10:45:00.000Z",
+          "scheduledTime": "2026-07-30T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -289,15 +289,15 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-07-28T10:50:00.000Z",
+          "scheduledTime": "2026-07-30T10:50:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -317,7 +317,7 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-07-28T10:16:00.000Z",
+          "scheduledTime": "2026-07-30T10:16:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -326,15 +326,15 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Chiclana",
-          "scheduledTime": "2026-07-28T10:44:00.000Z",
+          "scheduledTime": "2026-07-30T10:44:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -354,7 +354,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-07-28T10:05:00.000Z",
+          "scheduledTime": "2026-07-30T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -363,7 +363,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-07-28T10:10:00.000Z",
+          "scheduledTime": "2026-07-30T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -372,7 +372,7 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-07-28T10:21:00.000Z",
+          "scheduledTime": "2026-07-30T10:21:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -381,7 +381,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-07-28T10:35:00.000Z",
+          "scheduledTime": "2026-07-30T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -390,7 +390,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-07-28T10:40:00.000Z",
+          "scheduledTime": "2026-07-30T10:40:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -399,7 +399,7 @@
           "lineCode": "M-031",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
           "destination": "Puerto Real",
-          "scheduledTime": "2026-07-28T10:51:00.000Z",
+          "scheduledTime": "2026-07-30T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -408,15 +408,15 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-07-28T11:00:00.000Z",
+          "scheduledTime": "2026-07-30T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -436,7 +436,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-07-28T10:21:00.000Z",
+          "scheduledTime": "2026-07-30T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -445,7 +445,7 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-07-28T10:28:00.000Z",
+          "scheduledTime": "2026-07-30T10:28:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -454,7 +454,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-07-28T11:06:00.000Z",
+          "scheduledTime": "2026-07-30T11:06:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -463,7 +463,7 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-07-28T11:08:00.000Z",
+          "scheduledTime": "2026-07-30T11:08:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -472,7 +472,7 @@
           "lineCode": "0124",
           "lineName": "Granada - Atarfe",
           "destination": "Atarfe",
-          "scheduledTime": "2026-07-28T11:48:00.000Z",
+          "scheduledTime": "2026-07-30T11:48:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -481,15 +481,15 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-07-28T11:51:00.000Z",
+          "scheduledTime": "2026-07-30T11:51:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T12:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T12:00:00.000Z"
       }
     },
     {
@@ -509,7 +509,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Granada",
-          "scheduledTime": "2026-07-28T10:39:00.000Z",
+          "scheduledTime": "2026-07-30T10:39:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -518,7 +518,7 @@
           "lineCode": "0318",
           "lineName": "Granada - Colomera",
           "destination": "Cerro Cauro",
-          "scheduledTime": "2026-07-28T10:41:00.000Z",
+          "scheduledTime": "2026-07-30T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -527,15 +527,15 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Parque del Cubillas",
-          "scheduledTime": "2026-07-28T11:30:00.000Z",
+          "scheduledTime": "2026-07-30T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T12:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T12:00:00.000Z"
       }
     },
     {
@@ -555,7 +555,7 @@
           "lineCode": "0241",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
           "destination": "Cijuela",
-          "scheduledTime": "2026-07-28T10:26:00.000Z",
+          "scheduledTime": "2026-07-30T10:26:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -564,7 +564,7 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-07-28T11:27:00.000Z",
+          "scheduledTime": "2026-07-30T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -573,15 +573,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-07-28T11:57:00.000Z",
+          "scheduledTime": "2026-07-30T11:57:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T12:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T12:00:00.000Z"
       }
     },
     {
@@ -601,15 +601,15 @@
           "lineCode": "0340",
           "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
           "destination": "Granada",
-          "scheduledTime": "2026-07-28T11:01:00.000Z",
+          "scheduledTime": "2026-07-30T11:01:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T12:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T12:00:00.000Z"
       }
     },
     {
@@ -629,7 +629,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-07-28T10:00:00.000Z",
+          "scheduledTime": "2026-07-30T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -638,7 +638,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-07-28T10:01:00.000Z",
+          "scheduledTime": "2026-07-30T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -647,7 +647,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-07-28T10:45:00.000Z",
+          "scheduledTime": "2026-07-30T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -656,7 +656,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-07-28T11:15:00.000Z",
+          "scheduledTime": "2026-07-30T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -665,15 +665,15 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-07-28T11:46:00.000Z",
+          "scheduledTime": "2026-07-30T11:46:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T12:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T12:00:00.000Z"
       }
     },
     {
@@ -693,15 +693,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-07-28T10:11:00.000Z",
+          "scheduledTime": "2026-07-30T10:11:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T10:15:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T10:15:00.000Z"
       }
     },
     {
@@ -721,15 +721,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-07-28T10:08:00.000Z",
+          "scheduledTime": "2026-07-30T10:08:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T10:15:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T10:15:00.000Z"
       }
     },
     {
@@ -745,9 +745,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T10:15:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T10:15:00.000Z"
       }
     },
     {
@@ -767,15 +767,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-07-28T10:05:00.000Z",
+          "scheduledTime": "2026-07-30T10:05:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T10:15:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T10:15:00.000Z"
       }
     },
     {
@@ -795,15 +795,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-07-28T10:02:00.000Z",
+          "scheduledTime": "2026-07-30T10:02:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T10:15:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T10:15:00.000Z"
       }
     },
     {
@@ -819,9 +819,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -841,7 +841,7 @@
           "lineCode": "M-161",
           "lineName": "Barbate-Facinas-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-07-28T10:10:00.000Z",
+          "scheduledTime": "2026-07-30T10:10:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -850,15 +850,15 @@
           "lineCode": "M-150",
           "lineName": "Algeciras-Tarifa",
           "destination": "Algeciras",
-          "scheduledTime": "2026-07-28T10:45:00.000Z",
+          "scheduledTime": "2026-07-30T10:45:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -878,7 +878,7 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-07-28T10:30:00.000Z",
+          "scheduledTime": "2026-07-30T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -887,15 +887,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Algeciras",
-          "scheduledTime": "2026-07-28T10:30:00.000Z",
+          "scheduledTime": "2026-07-30T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -915,15 +915,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-07-28T10:03:00.000Z",
+          "scheduledTime": "2026-07-30T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -943,7 +943,7 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-07-28T10:45:00.000Z",
+          "scheduledTime": "2026-07-30T10:45:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -952,15 +952,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-07-28T11:00:00.000Z",
+          "scheduledTime": "2026-07-30T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -980,7 +980,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ADRA",
-          "scheduledTime": "2026-07-28T10:36:00.000Z",
+          "scheduledTime": "2026-07-30T10:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -989,7 +989,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-07-28T10:48:00.000Z",
+          "scheduledTime": "2026-07-30T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -998,15 +998,15 @@
           "lineCode": "M-384",
           "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
           "destination": "ADRA",
-          "scheduledTime": "2026-07-28T10:51:00.000Z",
+          "scheduledTime": "2026-07-30T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -1022,9 +1022,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -1040,9 +1040,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -1058,9 +1058,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -1076,9 +1076,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T11:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T11:00:00.000Z"
       }
     },
     {
@@ -1094,9 +1094,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T12:30:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T12:30:00.000Z"
       }
     },
     {
@@ -1116,7 +1116,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-07-28T10:20:00.000Z",
+          "scheduledTime": "2026-07-30T10:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1125,7 +1125,7 @@
           "lineCode": "M20-11",
           "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-28T10:38:00.000Z",
+          "scheduledTime": "2026-07-30T10:38:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1134,7 +1134,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-07-28T10:50:00.000Z",
+          "scheduledTime": "2026-07-30T10:50:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1143,7 +1143,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-28T11:13:00.000Z",
+          "scheduledTime": "2026-07-30T11:13:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1152,7 +1152,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-07-28T11:20:00.000Z",
+          "scheduledTime": "2026-07-30T11:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1161,7 +1161,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-28T11:43:00.000Z",
+          "scheduledTime": "2026-07-30T11:43:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1170,7 +1170,7 @@
           "lineCode": "M20-12",
           "lineName": "Jaén - Escañuela, 2024",
           "destination": "Escañuela",
-          "scheduledTime": "2026-07-28T11:55:00.000Z",
+          "scheduledTime": "2026-07-30T11:55:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1179,15 +1179,15 @@
           "lineCode": "M20-08",
           "lineName": "Jaén - Lopera, 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-07-28T12:20:00.000Z",
+          "scheduledTime": "2026-07-30T12:20:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T12:30:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T12:30:00.000Z"
       }
     },
     {
@@ -1207,7 +1207,7 @@
           "lineCode": "M20-11",
           "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-28T10:25:00.000Z",
+          "scheduledTime": "2026-07-30T10:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1216,7 +1216,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-07-28T10:33:00.000Z",
+          "scheduledTime": "2026-07-30T10:33:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1225,7 +1225,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-28T11:00:00.000Z",
+          "scheduledTime": "2026-07-30T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1234,7 +1234,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-07-28T11:03:00.000Z",
+          "scheduledTime": "2026-07-30T11:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1243,7 +1243,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-28T11:30:00.000Z",
+          "scheduledTime": "2026-07-30T11:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1252,7 +1252,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-07-28T11:33:00.000Z",
+          "scheduledTime": "2026-07-30T11:33:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1261,7 +1261,7 @@
           "lineCode": "M20-12",
           "lineName": "Jaén - Escañuela, 2024",
           "destination": "Escañuela",
-          "scheduledTime": "2026-07-28T12:08:00.000Z",
+          "scheduledTime": "2026-07-30T12:08:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1270,15 +1270,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-28T12:25:00.000Z",
+          "scheduledTime": "2026-07-30T12:25:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T12:30:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T12:30:00.000Z"
       }
     },
     {
@@ -1298,7 +1298,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-28T10:00:00.000Z",
+          "scheduledTime": "2026-07-30T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1307,7 +1307,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-28T10:05:00.000Z",
+          "scheduledTime": "2026-07-30T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1316,7 +1316,7 @@
           "lineCode": "M16-3",
           "lineName": "Bailén - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-07-28T10:15:00.000Z",
+          "scheduledTime": "2026-07-30T10:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1325,7 +1325,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-07-28T10:40:00.000Z",
+          "scheduledTime": "2026-07-30T10:40:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1334,7 +1334,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-07-28T11:00:00.000Z",
+          "scheduledTime": "2026-07-30T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1343,7 +1343,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-07-28T11:25:00.000Z",
+          "scheduledTime": "2026-07-30T11:25:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1352,7 +1352,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-28T11:30:00.000Z",
+          "scheduledTime": "2026-07-30T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1361,7 +1361,7 @@
           "lineCode": "M16-2",
           "lineName": "La Carolina - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-07-28T11:45:00.000Z",
+          "scheduledTime": "2026-07-30T11:45:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1370,7 +1370,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-07-28T11:55:00.000Z",
+          "scheduledTime": "2026-07-30T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1379,15 +1379,15 @@
           "lineCode": "M15-7",
           "lineName": "Jaén - Andújar - Marmolejo",
           "destination": "Andújar",
-          "scheduledTime": "2026-07-28T12:25:00.000Z",
+          "scheduledTime": "2026-07-30T12:25:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T12:30:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T12:30:00.000Z"
       }
     },
     {
@@ -1407,7 +1407,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-28T10:30:00.000Z",
+          "scheduledTime": "2026-07-30T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1416,7 +1416,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-07-28T10:55:00.000Z",
+          "scheduledTime": "2026-07-30T10:55:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1425,7 +1425,7 @@
           "lineCode": "M3-103",
           "lineName": "Úbeda - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-07-28T11:00:00.000Z",
+          "scheduledTime": "2026-07-30T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1434,7 +1434,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-28T11:30:00.000Z",
+          "scheduledTime": "2026-07-30T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1443,15 +1443,15 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-07-28T11:55:00.000Z",
+          "scheduledTime": "2026-07-30T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T12:30:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T12:30:00.000Z"
       }
     },
     {
@@ -1467,9 +1467,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-29T02:39:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-31T02:39:00.000Z"
       }
     },
     {
@@ -1485,9 +1485,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-29T02:39:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-31T02:39:00.000Z"
       }
     },
     {
@@ -1503,9 +1503,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-29T02:39:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-31T02:39:00.000Z"
       }
     },
     {
@@ -1521,9 +1521,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-29T02:39:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-31T02:39:00.000Z"
       }
     },
     {
@@ -1539,9 +1539,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-29T02:39:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-31T02:39:00.000Z"
       }
     },
     {
@@ -1561,7 +1561,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-28T10:00:00.000Z",
+          "scheduledTime": "2026-07-30T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1570,7 +1570,7 @@
           "lineCode": "M-303",
           "lineName": "Huelva-Corrales-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-28T10:04:00.000Z",
+          "scheduledTime": "2026-07-30T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1579,7 +1579,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-28T10:21:00.000Z",
+          "scheduledTime": "2026-07-30T10:21:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1588,7 +1588,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-28T10:42:00.000Z",
+          "scheduledTime": "2026-07-30T10:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1597,7 +1597,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-28T11:00:00.000Z",
+          "scheduledTime": "2026-07-30T11:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1606,7 +1606,7 @@
           "lineCode": "M-303",
           "lineName": "Huelva-Corrales-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-28T11:04:00.000Z",
+          "scheduledTime": "2026-07-30T11:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1615,7 +1615,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-28T11:11:00.000Z",
+          "scheduledTime": "2026-07-30T11:11:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1624,7 +1624,7 @@
           "lineCode": "M-902",
           "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-07-28T11:21:00.000Z",
+          "scheduledTime": "2026-07-30T11:21:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1633,7 +1633,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-28T11:41:00.000Z",
+          "scheduledTime": "2026-07-30T11:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1642,7 +1642,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-28T11:42:00.000Z",
+          "scheduledTime": "2026-07-30T11:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1651,7 +1651,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-28T11:44:00.000Z",
+          "scheduledTime": "2026-07-30T11:44:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1660,7 +1660,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-28T12:00:00.000Z",
+          "scheduledTime": "2026-07-30T12:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1669,7 +1669,7 @@
           "lineCode": "M-316",
           "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
           "destination": "VILLABLANCA",
-          "scheduledTime": "2026-07-28T12:36:00.000Z",
+          "scheduledTime": "2026-07-30T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1678,7 +1678,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-28T12:42:00.000Z",
+          "scheduledTime": "2026-07-30T12:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1687,7 +1687,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-28T13:00:00.000Z",
+          "scheduledTime": "2026-07-30T13:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1696,7 +1696,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-28T13:15:00.000Z",
+          "scheduledTime": "2026-07-30T13:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1705,7 +1705,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-28T13:21:00.000Z",
+          "scheduledTime": "2026-07-30T13:21:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1714,7 +1714,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-28T13:42:00.000Z",
+          "scheduledTime": "2026-07-30T13:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1723,15 +1723,15 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-28T13:44:00.000Z",
+          "scheduledTime": "2026-07-30T13:44:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T14:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T14:00:00.000Z"
       }
     },
     {
@@ -1751,7 +1751,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-28T10:49:00.000Z",
+          "scheduledTime": "2026-07-30T10:49:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1760,7 +1760,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-28T11:20:00.000Z",
+          "scheduledTime": "2026-07-30T11:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1769,7 +1769,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-28T11:50:00.000Z",
+          "scheduledTime": "2026-07-30T11:50:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1778,7 +1778,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-28T12:20:00.000Z",
+          "scheduledTime": "2026-07-30T12:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1787,7 +1787,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-28T12:30:00.000Z",
+          "scheduledTime": "2026-07-30T12:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1796,7 +1796,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-28T13:20:00.000Z",
+          "scheduledTime": "2026-07-30T13:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1805,15 +1805,15 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-28T13:49:00.000Z",
+          "scheduledTime": "2026-07-30T13:49:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T14:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T14:00:00.000Z"
       }
     },
     {
@@ -1833,7 +1833,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-28T10:03:00.000Z",
+          "scheduledTime": "2026-07-30T10:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1842,7 +1842,7 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-28T10:14:00.000Z",
+          "scheduledTime": "2026-07-30T10:14:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1851,7 +1851,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-07-28T10:48:00.000Z",
+          "scheduledTime": "2026-07-30T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1860,7 +1860,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-28T11:03:00.000Z",
+          "scheduledTime": "2026-07-30T11:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1869,7 +1869,7 @@
           "lineCode": "M-417",
           "lineName": "Paterna-Torre Higuera",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-07-28T11:18:00.000Z",
+          "scheduledTime": "2026-07-30T11:18:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1878,7 +1878,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-07-28T11:48:00.000Z",
+          "scheduledTime": "2026-07-30T11:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1887,7 +1887,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-28T12:03:00.000Z",
+          "scheduledTime": "2026-07-30T12:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1896,7 +1896,7 @@
           "lineCode": "M-405",
           "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-07-28T12:36:00.000Z",
+          "scheduledTime": "2026-07-30T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1905,7 +1905,7 @@
           "lineCode": "M-906",
           "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
           "destination": "ROCIANA DEL CONDADO",
-          "scheduledTime": "2026-07-28T12:43:00.000Z",
+          "scheduledTime": "2026-07-30T12:43:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1914,7 +1914,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-07-28T12:48:00.000Z",
+          "scheduledTime": "2026-07-30T12:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1923,7 +1923,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-28T13:03:00.000Z",
+          "scheduledTime": "2026-07-30T13:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1932,7 +1932,7 @@
           "lineCode": "M-417",
           "lineName": "Paterna-Torre Higuera",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-07-28T13:48:00.000Z",
+          "scheduledTime": "2026-07-30T13:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1941,7 +1941,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-07-28T13:48:00.000Z",
+          "scheduledTime": "2026-07-30T13:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1950,7 +1950,7 @@
           "lineCode": "M-405",
           "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-28T13:52:00.000Z",
+          "scheduledTime": "2026-07-30T13:52:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1959,15 +1959,15 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "HINOJOS",
-          "scheduledTime": "2026-07-28T13:58:00.000Z",
+          "scheduledTime": "2026-07-30T13:58:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T14:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T14:00:00.000Z"
       }
     },
     {
@@ -1983,9 +1983,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T14:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T14:00:00.000Z"
       }
     },
     {
@@ -2001,9 +2001,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-28T07:40:09.850Z",
-        "startTime": "2026-07-28T10:00:00.000Z",
-        "endTime": "2026-07-28T14:00:00.000Z"
+        "requestedAt": "2026-07-30T07:33:59.824Z",
+        "startTime": "2026-07-30T10:00:00.000Z",
+        "endTime": "2026-07-30T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:02.639Z",
+    "generatedAt": "2026-07-30T07:33:52.421Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:02.639Z",
+    "generatedAt": "2026-07-30T07:33:52.421Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:02.639Z",
+    "generatedAt": "2026-07-30T07:33:52.421Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:02.639Z",
+    "generatedAt": "2026-07-30T07:33:52.421Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:02.639Z",
+    "generatedAt": "2026-07-30T07:33:52.421Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:02.639Z",
+    "generatedAt": "2026-07-30T07:33:52.421Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:02.639Z",
+    "generatedAt": "2026-07-30T07:33:52.421Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:02.639Z",
+    "generatedAt": "2026-07-30T07:33:52.421Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:02.639Z",
+    "generatedAt": "2026-07-30T07:33:52.421Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-28T07:40:02.639Z",
+    "generatedAt": "2026-07-30T07:33:52.421Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-07-30 07:34 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Málaga–Torre del Mar Directo route, effective July 30.
  - Enabled news indicators for three routes.

- **Data Updates**
  - Refreshed transit catalog and stop-directory data across all service areas.
  - Updated the latest stop-service snapshot with current scheduled times and query windows.
  - Catalog and stop information now reflects the latest generation timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->