### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,
     "consortiumName": "Área de Sevilla",
-    "itemCount": 116
+    "itemCount": 112
   },
   "lines": [
     {
@@ -1284,30 +1284,6 @@
       "inboundPath": []
     },
     {
-      "id": "303",
-      "code": "1423",
-      "name": "M-142B Coria del Río - Sevilla (recorrido B)",
-      "mode": "Bus",
-      "modeId": "1",
-      "operators": [
-        "TRANVIAS DE SEVILLA S.A"
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
       "id": "324",
       "code": "1431",
       "name": "M-143 Isla Mayor - Sevilla",
@@ -1335,30 +1311,6 @@
       "id": "448",
       "code": "1432",
       "name": "M-143 Isla Mayor - Sevilla (sab, dom y fest)",
-      "mode": "Bus",
-      "modeId": "1",
-      "operators": [
-        "TRANVIAS DE SEVILLA S.A"
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "306",
-      "code": "1511",
-      "name": "M-151 Urb Puebla del Marques - Sevilla",
       "mode": "Bus",
       "modeId": "1",
       "operators": [
@@ -1863,54 +1815,6 @@
       "id": "279",
       "code": "1661",
       "name": "M-166 Sanlúcar la Mayor - Sevilla",
-      "mode": "Bus",
-      "modeId": "1",
-      "operators": [
-        "DAMAS S.A"
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "278",
-      "code": "1660",
-      "name": "M-166 Sanlúcar la Mayor - Sevilla (directo, laborables)",
-      "mode": "Bus",
-      "modeId": "1",
-      "operators": [
-        "DAMAS S.A"
-      ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "283",
-      "code": "1665",
-      "name": "M-166 Sanlúcar la Mayor - Sevilla (por A-49, laborables)",
       "mode": "Bus",
       "modeId": "1",
       "operators": [

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,
     "consortiumName": "Bahía de Cádiz",
-    "itemCount": 62
+    "itemCount": 61
   },
   "lines": [
     {
@@ -756,30 +756,6 @@
       "id": "6",
       "code": "M-030",
       "name": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-      "mode": "AUTOBUS",
-      "modeId": "1",
-      "operators": [
-        "Transportes Generales Comes S.A."
-      ],
-      "hasNews": true,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "10",
-      "code": "M-032",
-      "name": "Cádiz-Río San Pedro-Puerto Real (512 Viviendas)",
       "mode": "AUTOBUS",
       "modeId": "1",
       "operators": [

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,
     "consortiumName": "Área de Granada",
-    "itemCount": 70
+    "itemCount": 69
   },
   "lines": [
     {
@@ -917,7 +917,7 @@
         "Bus Metropolitano de Granada",
         "S.L."
       ],
-      "hasNews": false,
+      "hasNews": true,
       "concession": null,
       "notes": null,
       "modeNotes": null,
@@ -942,32 +942,7 @@
         "Bus Metropolitano de Granada",
         "S.L."
       ],
-      "hasNews": false,
-      "concession": null,
-      "notes": null,
-      "modeNotes": null,
-      "accessibility": null,
-      "thickness": null,
-      "color": null,
-      "outboundThermometerUrl": null,
-      "inboundThermometerUrl": null,
-      "hasOutbound": false,
-      "hasInbound": false,
-      "path": [],
-      "outboundPath": [],
-      "inboundPath": []
-    },
-    {
-      "id": "995",
-      "code": "0174A",
-      "name": "Granada - Ogíjares - Zubia (Circular)",
-      "mode": "AUTOBUS",
-      "modeId": "1",
-      "operators": [
-        "Bus Metropolitano de Granada",
-        "S.L."
-      ],
-      "hasNews": false,
+      "hasNews": true,
       "concession": null,
       "notes": null,
       "modeNotes": null,
@@ -1642,7 +1617,7 @@
         "Bus Metropolitano de Granada",
         "S.L."
       ],
-      "hasNews": false,
+      "hasNews": true,
       "concession": null,
       "notes": null,
       "modeNotes": null,
@@ -1667,7 +1642,7 @@
         "Bus Metropolitano de Granada",
         "S.L."
       ],
-      "hasNews": false,
+      "hasNews": true,
       "concession": null,
       "notes": null,
       "modeNotes": null,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:55.997Z",
+    "generatedAt": "2026-07-31T07:51:47.864Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:59.824Z",
+    "generatedAt": "2026-07-31T07:51:52.300Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -23,15 +23,15 @@
           "lineCode": "1320",
           "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-07-30T10:07:00.000Z",
+          "scheduledTime": "2026-07-31T10:07:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -45,39 +45,11 @@
       },
       "municipality": "ESPARTINAS",
       "nucleus": "ESPARTINAS",
-      "services": [
-        {
-          "lineId": "284",
-          "lineCode": "1666",
-          "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-07-30T10:31:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "295",
-          "lineCode": "1681",
-          "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-07-30T10:42:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "279",
-          "lineCode": "1661",
-          "lineName": "M-166 Sanlúcar la Mayor - Sevilla",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-07-30T10:48:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -91,30 +63,11 @@
       },
       "municipality": "SANTIPONCE",
       "nucleus": "SANTIPONCE",
-      "services": [
-        {
-          "lineId": "287",
-          "lineCode": "1720",
-          "lineName": "M-170A Santiponce - Sevilla",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-07-30T10:02:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "1720",
-          "lineName": "M-170A Santiponce - Sevilla",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-07-30T10:32:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -130,9 +83,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -148,37 +101,19 @@
       "nucleus": "SEVILLA",
       "services": [
         {
-          "lineId": "232",
-          "lineCode": "1100",
-          "lineName": "M-110 La Algaba - Sevilla",
-          "destination": "LA ALGABA",
-          "scheduledTime": "2026-07-30T10:04:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
           "lineId": "238",
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-07-30T10:04:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "232",
-          "lineCode": "1100",
-          "lineName": "M-110 La Algaba - Sevilla",
-          "destination": "LA ALGABA",
-          "scheduledTime": "2026-07-30T10:34:00.000Z",
+          "scheduledTime": "2026-07-31T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -198,15 +133,15 @@
           "lineCode": "M-560",
           "lineName": "Rota-Jerez De La Frontera",
           "destination": "Rota",
-          "scheduledTime": "2026-07-30T10:00:00.000Z",
+          "scheduledTime": "2026-07-31T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -222,9 +157,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -244,7 +179,7 @@
           "lineCode": "M-967",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-07-30T10:05:00.000Z",
+          "scheduledTime": "2026-07-31T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -253,7 +188,7 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Jerez",
-          "scheduledTime": "2026-07-30T10:05:00.000Z",
+          "scheduledTime": "2026-07-31T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -262,7 +197,7 @@
           "lineCode": "M-967",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-07-30T10:28:00.000Z",
+          "scheduledTime": "2026-07-31T10:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -271,7 +206,7 @@
           "lineCode": "M-962",
           "lineName": "Chipiona-Sanlúcar De Barrameda-San Fernando (Por Puerto Real Y Hospital)",
           "destination": "San Fernando",
-          "scheduledTime": "2026-07-30T10:35:00.000Z",
+          "scheduledTime": "2026-07-31T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -280,7 +215,7 @@
           "lineCode": "M-561",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
           "destination": "Jerez",
-          "scheduledTime": "2026-07-30T10:45:00.000Z",
+          "scheduledTime": "2026-07-31T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -289,15 +224,15 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-07-30T10:50:00.000Z",
+          "scheduledTime": "2026-07-31T10:50:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -317,7 +252,7 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-07-30T10:16:00.000Z",
+          "scheduledTime": "2026-07-31T10:16:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -326,15 +261,15 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Chiclana",
-          "scheduledTime": "2026-07-30T10:44:00.000Z",
+          "scheduledTime": "2026-07-31T10:44:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -354,7 +289,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-07-30T10:05:00.000Z",
+          "scheduledTime": "2026-07-31T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -363,7 +298,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-07-30T10:10:00.000Z",
+          "scheduledTime": "2026-07-31T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -372,7 +307,7 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-07-30T10:21:00.000Z",
+          "scheduledTime": "2026-07-31T10:21:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -381,7 +316,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-07-30T10:35:00.000Z",
+          "scheduledTime": "2026-07-31T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -390,33 +325,24 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-07-30T10:40:00.000Z",
+          "scheduledTime": "2026-07-31T10:40:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "9",
-          "lineCode": "M-031",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
-          "destination": "Puerto Real",
-          "scheduledTime": "2026-07-30T10:51:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
           "lineId": "6",
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-07-30T11:00:00.000Z",
+          "scheduledTime": "2026-07-31T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -436,16 +362,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-07-30T10:21:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "1077",
-          "lineCode": "0124",
-          "lineName": "Granada - Atarfe",
-          "destination": "Atarfe",
-          "scheduledTime": "2026-07-30T10:28:00.000Z",
+          "scheduledTime": "2026-07-31T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -454,25 +371,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-07-30T11:06:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "1077",
-          "lineCode": "0124",
-          "lineName": "Granada - Atarfe",
-          "destination": "Atarfe",
-          "scheduledTime": "2026-07-30T11:08:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "1077",
-          "lineCode": "0124",
-          "lineName": "Granada - Atarfe",
-          "destination": "Atarfe",
-          "scheduledTime": "2026-07-30T11:48:00.000Z",
+          "scheduledTime": "2026-07-31T11:06:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -481,15 +380,15 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-07-30T11:51:00.000Z",
+          "scheduledTime": "2026-07-31T11:51:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T12:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T12:00:00.000Z"
       }
     },
     {
@@ -509,7 +408,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Granada",
-          "scheduledTime": "2026-07-30T10:39:00.000Z",
+          "scheduledTime": "2026-07-31T10:39:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -518,7 +417,7 @@
           "lineCode": "0318",
           "lineName": "Granada - Colomera",
           "destination": "Cerro Cauro",
-          "scheduledTime": "2026-07-30T10:41:00.000Z",
+          "scheduledTime": "2026-07-31T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -527,15 +426,15 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Parque del Cubillas",
-          "scheduledTime": "2026-07-30T11:30:00.000Z",
+          "scheduledTime": "2026-07-31T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T12:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T12:00:00.000Z"
       }
     },
     {
@@ -555,7 +454,7 @@
           "lineCode": "0241",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
           "destination": "Cijuela",
-          "scheduledTime": "2026-07-30T10:26:00.000Z",
+          "scheduledTime": "2026-07-31T10:26:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -564,7 +463,7 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-07-30T11:27:00.000Z",
+          "scheduledTime": "2026-07-31T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -573,15 +472,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-07-30T11:57:00.000Z",
+          "scheduledTime": "2026-07-31T11:57:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T12:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T12:00:00.000Z"
       }
     },
     {
@@ -601,15 +500,15 @@
           "lineCode": "0340",
           "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
           "destination": "Granada",
-          "scheduledTime": "2026-07-30T11:01:00.000Z",
+          "scheduledTime": "2026-07-31T11:01:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T12:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T12:00:00.000Z"
       }
     },
     {
@@ -629,7 +528,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-07-30T10:00:00.000Z",
+          "scheduledTime": "2026-07-31T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -638,7 +537,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-07-30T10:01:00.000Z",
+          "scheduledTime": "2026-07-31T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -647,7 +546,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-07-30T10:45:00.000Z",
+          "scheduledTime": "2026-07-31T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -656,7 +555,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-07-30T11:15:00.000Z",
+          "scheduledTime": "2026-07-31T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -665,15 +564,15 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-07-30T11:46:00.000Z",
+          "scheduledTime": "2026-07-31T11:46:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T12:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T12:00:00.000Z"
       }
     },
     {
@@ -693,15 +592,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-07-30T10:11:00.000Z",
+          "scheduledTime": "2026-07-31T10:11:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T10:15:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T10:15:00.000Z"
       }
     },
     {
@@ -721,15 +620,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-07-30T10:08:00.000Z",
+          "scheduledTime": "2026-07-31T10:08:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T10:15:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T10:15:00.000Z"
       }
     },
     {
@@ -745,9 +644,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T10:15:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T10:15:00.000Z"
       }
     },
     {
@@ -767,15 +666,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-07-30T10:05:00.000Z",
+          "scheduledTime": "2026-07-31T10:05:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T10:15:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T10:15:00.000Z"
       }
     },
     {
@@ -795,15 +694,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-07-30T10:02:00.000Z",
+          "scheduledTime": "2026-07-31T10:02:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T10:15:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T10:15:00.000Z"
       }
     },
     {
@@ -819,9 +718,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -841,7 +740,7 @@
           "lineCode": "M-161",
           "lineName": "Barbate-Facinas-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-07-30T10:10:00.000Z",
+          "scheduledTime": "2026-07-31T10:10:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -850,15 +749,15 @@
           "lineCode": "M-150",
           "lineName": "Algeciras-Tarifa",
           "destination": "Algeciras",
-          "scheduledTime": "2026-07-30T10:45:00.000Z",
+          "scheduledTime": "2026-07-31T10:45:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -878,7 +777,7 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-07-30T10:30:00.000Z",
+          "scheduledTime": "2026-07-31T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -887,15 +786,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Algeciras",
-          "scheduledTime": "2026-07-30T10:30:00.000Z",
+          "scheduledTime": "2026-07-31T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -915,15 +814,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-07-30T10:03:00.000Z",
+          "scheduledTime": "2026-07-31T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -943,7 +842,7 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-07-30T10:45:00.000Z",
+          "scheduledTime": "2026-07-31T10:45:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -952,15 +851,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-07-30T11:00:00.000Z",
+          "scheduledTime": "2026-07-31T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -980,7 +879,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ADRA",
-          "scheduledTime": "2026-07-30T10:36:00.000Z",
+          "scheduledTime": "2026-07-31T10:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -989,7 +888,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-07-30T10:48:00.000Z",
+          "scheduledTime": "2026-07-31T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -998,15 +897,15 @@
           "lineCode": "M-384",
           "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
           "destination": "ADRA",
-          "scheduledTime": "2026-07-30T10:51:00.000Z",
+          "scheduledTime": "2026-07-31T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -1022,9 +921,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -1040,9 +939,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -1058,9 +957,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -1076,9 +975,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T11:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T11:00:00.000Z"
       }
     },
     {
@@ -1094,9 +993,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T12:30:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T12:30:00.000Z"
       }
     },
     {
@@ -1116,7 +1015,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-07-30T10:20:00.000Z",
+          "scheduledTime": "2026-07-31T10:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1125,7 +1024,7 @@
           "lineCode": "M20-11",
           "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-30T10:38:00.000Z",
+          "scheduledTime": "2026-07-31T10:38:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1134,7 +1033,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-07-30T10:50:00.000Z",
+          "scheduledTime": "2026-07-31T10:50:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1143,7 +1042,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-30T11:13:00.000Z",
+          "scheduledTime": "2026-07-31T11:13:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1152,7 +1051,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-07-30T11:20:00.000Z",
+          "scheduledTime": "2026-07-31T11:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1161,7 +1060,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-30T11:43:00.000Z",
+          "scheduledTime": "2026-07-31T11:43:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1170,7 +1069,7 @@
           "lineCode": "M20-12",
           "lineName": "Jaén - Escañuela, 2024",
           "destination": "Escañuela",
-          "scheduledTime": "2026-07-30T11:55:00.000Z",
+          "scheduledTime": "2026-07-31T11:55:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1179,15 +1078,15 @@
           "lineCode": "M20-08",
           "lineName": "Jaén - Lopera, 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-07-30T12:20:00.000Z",
+          "scheduledTime": "2026-07-31T12:20:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T12:30:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T12:30:00.000Z"
       }
     },
     {
@@ -1207,7 +1106,7 @@
           "lineCode": "M20-11",
           "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-30T10:25:00.000Z",
+          "scheduledTime": "2026-07-31T10:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1216,7 +1115,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-07-30T10:33:00.000Z",
+          "scheduledTime": "2026-07-31T10:33:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1225,7 +1124,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-30T11:00:00.000Z",
+          "scheduledTime": "2026-07-31T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1234,7 +1133,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-07-30T11:03:00.000Z",
+          "scheduledTime": "2026-07-31T11:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1243,7 +1142,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-30T11:30:00.000Z",
+          "scheduledTime": "2026-07-31T11:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1252,7 +1151,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-07-30T11:33:00.000Z",
+          "scheduledTime": "2026-07-31T11:33:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1261,7 +1160,7 @@
           "lineCode": "M20-12",
           "lineName": "Jaén - Escañuela, 2024",
           "destination": "Escañuela",
-          "scheduledTime": "2026-07-30T12:08:00.000Z",
+          "scheduledTime": "2026-07-31T12:08:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1270,15 +1169,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-30T12:25:00.000Z",
+          "scheduledTime": "2026-07-31T12:25:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T12:30:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T12:30:00.000Z"
       }
     },
     {
@@ -1298,7 +1197,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-30T10:00:00.000Z",
+          "scheduledTime": "2026-07-31T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1307,7 +1206,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-30T10:05:00.000Z",
+          "scheduledTime": "2026-07-31T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1316,7 +1215,7 @@
           "lineCode": "M16-3",
           "lineName": "Bailén - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-07-30T10:15:00.000Z",
+          "scheduledTime": "2026-07-31T10:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1325,7 +1224,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-07-30T10:40:00.000Z",
+          "scheduledTime": "2026-07-31T10:40:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1334,7 +1233,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-07-30T11:00:00.000Z",
+          "scheduledTime": "2026-07-31T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1343,7 +1242,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-07-30T11:25:00.000Z",
+          "scheduledTime": "2026-07-31T11:25:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1352,7 +1251,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-30T11:30:00.000Z",
+          "scheduledTime": "2026-07-31T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1361,7 +1260,7 @@
           "lineCode": "M16-2",
           "lineName": "La Carolina - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-07-30T11:45:00.000Z",
+          "scheduledTime": "2026-07-31T11:45:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1370,7 +1269,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-07-30T11:55:00.000Z",
+          "scheduledTime": "2026-07-31T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1379,15 +1278,15 @@
           "lineCode": "M15-7",
           "lineName": "Jaén - Andújar - Marmolejo",
           "destination": "Andújar",
-          "scheduledTime": "2026-07-30T12:25:00.000Z",
+          "scheduledTime": "2026-07-31T12:25:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T12:30:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T12:30:00.000Z"
       }
     },
     {
@@ -1407,7 +1306,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-30T10:30:00.000Z",
+          "scheduledTime": "2026-07-31T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1416,7 +1315,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-07-30T10:55:00.000Z",
+          "scheduledTime": "2026-07-31T10:55:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1425,7 +1324,7 @@
           "lineCode": "M3-103",
           "lineName": "Úbeda - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-07-30T11:00:00.000Z",
+          "scheduledTime": "2026-07-31T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1434,7 +1333,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-30T11:30:00.000Z",
+          "scheduledTime": "2026-07-31T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1443,15 +1342,15 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-07-30T11:55:00.000Z",
+          "scheduledTime": "2026-07-31T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T12:30:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T12:30:00.000Z"
       }
     },
     {
@@ -1467,9 +1366,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-31T02:39:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-08-01T02:39:00.000Z"
       }
     },
     {
@@ -1485,9 +1384,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-31T02:39:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-08-01T02:39:00.000Z"
       }
     },
     {
@@ -1503,9 +1402,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-31T02:39:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-08-01T02:39:00.000Z"
       }
     },
     {
@@ -1521,9 +1420,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-31T02:39:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-08-01T02:39:00.000Z"
       }
     },
     {
@@ -1539,9 +1438,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-31T02:39:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-08-01T02:39:00.000Z"
       }
     },
     {
@@ -1561,7 +1460,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-30T10:00:00.000Z",
+          "scheduledTime": "2026-07-31T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1570,7 +1469,7 @@
           "lineCode": "M-303",
           "lineName": "Huelva-Corrales-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-30T10:04:00.000Z",
+          "scheduledTime": "2026-07-31T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1579,7 +1478,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-30T10:21:00.000Z",
+          "scheduledTime": "2026-07-31T10:21:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1588,7 +1487,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-30T10:42:00.000Z",
+          "scheduledTime": "2026-07-31T10:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1597,7 +1496,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-30T11:00:00.000Z",
+          "scheduledTime": "2026-07-31T11:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1606,7 +1505,7 @@
           "lineCode": "M-303",
           "lineName": "Huelva-Corrales-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-30T11:04:00.000Z",
+          "scheduledTime": "2026-07-31T11:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1615,7 +1514,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-30T11:11:00.000Z",
+          "scheduledTime": "2026-07-31T11:11:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1624,7 +1523,7 @@
           "lineCode": "M-902",
           "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-07-30T11:21:00.000Z",
+          "scheduledTime": "2026-07-31T11:21:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1633,7 +1532,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-30T11:41:00.000Z",
+          "scheduledTime": "2026-07-31T11:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1642,7 +1541,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-30T11:42:00.000Z",
+          "scheduledTime": "2026-07-31T11:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1651,7 +1550,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-30T11:44:00.000Z",
+          "scheduledTime": "2026-07-31T11:44:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1660,7 +1559,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-30T12:00:00.000Z",
+          "scheduledTime": "2026-07-31T12:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1669,7 +1568,7 @@
           "lineCode": "M-316",
           "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
           "destination": "VILLABLANCA",
-          "scheduledTime": "2026-07-30T12:36:00.000Z",
+          "scheduledTime": "2026-07-31T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1678,7 +1577,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-30T12:42:00.000Z",
+          "scheduledTime": "2026-07-31T12:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1687,7 +1586,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-30T13:00:00.000Z",
+          "scheduledTime": "2026-07-31T13:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1696,7 +1595,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-30T13:15:00.000Z",
+          "scheduledTime": "2026-07-31T13:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1705,7 +1604,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-30T13:21:00.000Z",
+          "scheduledTime": "2026-07-31T13:21:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1714,7 +1613,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-30T13:42:00.000Z",
+          "scheduledTime": "2026-07-31T13:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1723,15 +1622,15 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-30T13:44:00.000Z",
+          "scheduledTime": "2026-07-31T13:44:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T14:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T14:00:00.000Z"
       }
     },
     {
@@ -1751,7 +1650,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-30T10:49:00.000Z",
+          "scheduledTime": "2026-07-31T10:49:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1760,7 +1659,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-30T11:20:00.000Z",
+          "scheduledTime": "2026-07-31T11:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1769,7 +1668,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-30T11:50:00.000Z",
+          "scheduledTime": "2026-07-31T11:50:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1778,7 +1677,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-30T12:20:00.000Z",
+          "scheduledTime": "2026-07-31T12:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1787,7 +1686,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-30T12:30:00.000Z",
+          "scheduledTime": "2026-07-31T12:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1796,7 +1695,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-30T13:20:00.000Z",
+          "scheduledTime": "2026-07-31T13:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1805,15 +1704,15 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-30T13:49:00.000Z",
+          "scheduledTime": "2026-07-31T13:49:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T14:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T14:00:00.000Z"
       }
     },
     {
@@ -1833,7 +1732,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-30T10:03:00.000Z",
+          "scheduledTime": "2026-07-31T10:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1842,7 +1741,7 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-30T10:14:00.000Z",
+          "scheduledTime": "2026-07-31T10:14:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1851,7 +1750,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-07-30T10:48:00.000Z",
+          "scheduledTime": "2026-07-31T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1860,7 +1759,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-30T11:03:00.000Z",
+          "scheduledTime": "2026-07-31T11:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1869,7 +1768,7 @@
           "lineCode": "M-417",
           "lineName": "Paterna-Torre Higuera",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-07-30T11:18:00.000Z",
+          "scheduledTime": "2026-07-31T11:18:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1878,7 +1777,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-07-30T11:48:00.000Z",
+          "scheduledTime": "2026-07-31T11:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1887,7 +1786,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-30T12:03:00.000Z",
+          "scheduledTime": "2026-07-31T12:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1896,7 +1795,7 @@
           "lineCode": "M-405",
           "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-07-30T12:36:00.000Z",
+          "scheduledTime": "2026-07-31T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1905,7 +1804,7 @@
           "lineCode": "M-906",
           "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
           "destination": "ROCIANA DEL CONDADO",
-          "scheduledTime": "2026-07-30T12:43:00.000Z",
+          "scheduledTime": "2026-07-31T12:43:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1914,7 +1813,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-07-30T12:48:00.000Z",
+          "scheduledTime": "2026-07-31T12:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1923,7 +1822,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-30T13:03:00.000Z",
+          "scheduledTime": "2026-07-31T13:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1932,7 +1831,7 @@
           "lineCode": "M-417",
           "lineName": "Paterna-Torre Higuera",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-07-30T13:48:00.000Z",
+          "scheduledTime": "2026-07-31T13:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1941,7 +1840,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-07-30T13:48:00.000Z",
+          "scheduledTime": "2026-07-31T13:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1950,7 +1849,7 @@
           "lineCode": "M-405",
           "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-30T13:52:00.000Z",
+          "scheduledTime": "2026-07-31T13:52:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1959,15 +1858,15 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "HINOJOS",
-          "scheduledTime": "2026-07-30T13:58:00.000Z",
+          "scheduledTime": "2026-07-31T13:58:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T14:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T14:00:00.000Z"
       }
     },
     {
@@ -1983,9 +1882,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T14:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T14:00:00.000Z"
       }
     },
     {
@@ -2001,9 +1900,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-30T07:33:59.824Z",
-        "startTime": "2026-07-30T10:00:00.000Z",
-        "endTime": "2026-07-30T14:00:00.000Z"
+        "requestedAt": "2026-07-31T07:51:52.300Z",
+        "startTime": "2026-07-31T10:00:00.000Z",
+        "endTime": "2026-07-31T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:52.421Z",
+    "generatedAt": "2026-07-31T07:51:43.561Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:52.421Z",
+    "generatedAt": "2026-07-31T07:51:43.561Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:52.421Z",
+    "generatedAt": "2026-07-31T07:51:43.561Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:52.421Z",
+    "generatedAt": "2026-07-31T07:51:43.561Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:52.421Z",
+    "generatedAt": "2026-07-31T07:51:43.561Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:52.421Z",
+    "generatedAt": "2026-07-31T07:51:43.561Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:52.421Z",
+    "generatedAt": "2026-07-31T07:51:43.561Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:52.421Z",
+    "generatedAt": "2026-07-31T07:51:43.561Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:52.421Z",
+    "generatedAt": "2026-07-31T07:51:43.561Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-30T07:33:52.421Z",
+    "generatedAt": "2026-07-31T07:51:43.561Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-07-31 07:52 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Refreshed transit catalogs and stop directories with the latest generated data.
  * Removed several discontinued bus-line entries and updated route counts.
  * Marked selected Granada routes as having new information.
* **Service Information**
  * Updated the latest stop-service snapshot with revised departures, routes, service availability, and operating windows.
  * Some service periods now extend into August 1, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->