### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,
@@ -93,7 +93,7 @@
         "NEX Continental Holdings",
         "S.L.U."
       ],
-      "hasNews": true,
+      "hasNews": false,
       "concession": null,
       "notes": null,
       "modeNotes": null,
@@ -268,7 +268,7 @@
         "NEX Continental Holdings",
         "S.L.U."
       ],
-      "hasNews": true,
+      "hasNews": false,
       "concession": null,
       "notes": null,
       "modeNotes": null,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:47.864Z",
+    "generatedAt": "2026-08-01T07:28:20.352Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:52.300Z",
+    "generatedAt": "2026-08-01T07:28:24.372Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -17,21 +17,11 @@
       },
       "municipality": "DOS HERMANAS",
       "nucleus": "FUENTE DEL REY (Dos Hermanas) zonaC",
-      "services": [
-        {
-          "lineId": "242",
-          "lineCode": "1320",
-          "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-07-31T10:07:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -45,11 +35,30 @@
       },
       "municipality": "ESPARTINAS",
       "nucleus": "ESPARTINAS",
-      "services": [],
+      "services": [
+        {
+          "lineId": "284",
+          "lineCode": "1666",
+          "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-08-01T10:31:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "295",
+          "lineCode": "1681",
+          "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-08-01T10:57:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        }
+      ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -65,9 +74,9 @@
       "nucleus": "SANTIPONCE",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -83,9 +92,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -101,19 +110,28 @@
       "nucleus": "SEVILLA",
       "services": [
         {
+          "lineId": "232",
+          "lineCode": "1100",
+          "lineName": "M-110 La Algaba - Sevilla",
+          "destination": "LA ALGABA",
+          "scheduledTime": "2026-08-01T10:04:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
           "lineId": "238",
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-07-31T10:04:00.000Z",
+          "scheduledTime": "2026-08-01T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -133,15 +151,24 @@
           "lineCode": "M-560",
           "lineName": "Rota-Jerez De La Frontera",
           "destination": "Rota",
-          "scheduledTime": "2026-07-31T10:00:00.000Z",
+          "scheduledTime": "2026-08-01T10:30:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "32",
+          "lineCode": "M-560",
+          "lineName": "Rota-Jerez De La Frontera",
+          "destination": "Jerez",
+          "scheduledTime": "2026-08-01T11:00:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -157,9 +184,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -175,11 +202,11 @@
       "nucleus": "Sanlúcar de Barrameda",
       "services": [
         {
-          "lineId": "225",
-          "lineCode": "M-967",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
+          "lineId": "163",
+          "lineCode": "M-960",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-07-31T10:05:00.000Z",
+          "scheduledTime": "2026-08-01T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -188,26 +215,26 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Jerez",
-          "scheduledTime": "2026-07-31T10:05:00.000Z",
+          "scheduledTime": "2026-08-01T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "225",
-          "lineCode": "M-967",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
+          "lineId": "230",
+          "lineCode": "M-965",
+          "lineName": "Chipiona-Sanlúcar De Barrameda (Sevilla/Utrera)",
+          "destination": "Sanlúcar de Barrameda",
+          "scheduledTime": "2026-08-01T10:05:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "230",
+          "lineCode": "M-965",
+          "lineName": "Chipiona-Sanlúcar De Barrameda (Sevilla/Utrera)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-07-31T10:28:00.000Z",
+          "scheduledTime": "2026-08-01T10:11:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "165",
-          "lineCode": "M-962",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-San Fernando (Por Puerto Real Y Hospital)",
-          "destination": "San Fernando",
-          "scheduledTime": "2026-07-31T10:35:00.000Z",
-          "direction": 1,
           "stopType": 0
         },
         {
@@ -215,24 +242,15 @@
           "lineCode": "M-561",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
           "destination": "Jerez",
-          "scheduledTime": "2026-07-31T10:45:00.000Z",
+          "scheduledTime": "2026-08-01T10:45:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "167",
-          "lineCode": "M-964",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
-          "destination": "Chipiona",
-          "scheduledTime": "2026-07-31T10:50:00.000Z",
-          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -246,30 +264,11 @@
       },
       "municipality": "Chiclana",
       "nucleus": "Chiclana",
-      "services": [
-        {
-          "lineId": "26",
-          "lineCode": "M-230",
-          "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
-          "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-07-31T10:16:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "26",
-          "lineCode": "M-230",
-          "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
-          "destination": "Chiclana",
-          "scheduledTime": "2026-07-31T10:44:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -288,17 +287,8 @@
           "lineId": "6",
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-07-31T10:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-07-31T10:10:00.000Z",
+          "scheduledTime": "2026-08-01T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -307,42 +297,15 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-07-31T10:21:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-07-31T10:35:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Cádiz",
-          "scheduledTime": "2026-07-31T10:40:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Cádiz",
-          "scheduledTime": "2026-07-31T11:00:00.000Z",
+          "scheduledTime": "2026-08-01T10:21:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -362,33 +325,24 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-07-31T10:21:00.000Z",
+          "scheduledTime": "2026-08-01T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
         {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-07-31T11:06:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-07-31T11:51:00.000Z",
+          "lineId": "992",
+          "lineCode": "0226",
+          "lineName": "Granada - P.Puente - Zujaira",
+          "destination": "Zujaira",
+          "scheduledTime": "2026-08-01T11:49:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T12:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T12:00:00.000Z"
       }
     },
     {
@@ -407,17 +361,8 @@
           "lineId": "1032",
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
-          "destination": "Granada",
-          "scheduledTime": "2026-07-31T10:39:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "710",
-          "lineCode": "0318",
-          "lineName": "Granada - Colomera",
-          "destination": "Cerro Cauro",
-          "scheduledTime": "2026-07-31T10:41:00.000Z",
+          "destination": "Centro Penitenciario de Albolote",
+          "scheduledTime": "2026-08-01T10:15:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -425,16 +370,25 @@
           "lineId": "1032",
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
-          "destination": "Parque del Cubillas",
-          "scheduledTime": "2026-07-31T11:30:00.000Z",
+          "destination": "Granada",
+          "scheduledTime": "2026-08-01T11:09:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "1032",
+          "lineCode": "0117",
+          "lineName": "Granada - P.Cubillas",
+          "destination": "Centro Penitenciario de Albolote",
+          "scheduledTime": "2026-08-01T11:45:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T12:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T12:00:00.000Z"
       }
     },
     {
@@ -450,11 +404,11 @@
       "nucleus": "Chauchina",
       "services": [
         {
-          "lineId": "868",
-          "lineCode": "0241",
-          "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
-          "destination": "Cijuela",
-          "scheduledTime": "2026-07-31T10:26:00.000Z",
+          "lineId": "1119",
+          "lineCode": "0242",
+          "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
+          "destination": "Láchar",
+          "scheduledTime": "2026-08-01T10:27:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -463,24 +417,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-07-31T11:27:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1119",
-          "lineCode": "0242",
-          "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
-          "destination": "Láchar",
-          "scheduledTime": "2026-07-31T11:57:00.000Z",
+          "scheduledTime": "2026-08-01T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T12:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T12:00:00.000Z"
       }
     },
     {
@@ -494,21 +439,11 @@
       },
       "municipality": "Cijuela",
       "nucleus": "Cijuela",
-      "services": [
-        {
-          "lineId": "877",
-          "lineCode": "0340",
-          "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
-          "destination": "Granada",
-          "scheduledTime": "2026-07-31T11:01:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T12:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T12:00:00.000Z"
       }
     },
     {
@@ -528,7 +463,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-07-31T10:00:00.000Z",
+          "scheduledTime": "2026-08-01T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -537,7 +472,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-07-31T10:01:00.000Z",
+          "scheduledTime": "2026-08-01T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -546,7 +481,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-07-31T10:45:00.000Z",
+          "scheduledTime": "2026-08-01T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -555,7 +490,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-07-31T11:15:00.000Z",
+          "scheduledTime": "2026-08-01T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -564,15 +499,15 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-07-31T11:46:00.000Z",
+          "scheduledTime": "2026-08-01T11:31:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T12:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T12:00:00.000Z"
       }
     },
     {
@@ -586,21 +521,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-07-31T10:11:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T10:15:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T10:15:00.000Z"
       }
     },
     {
@@ -614,21 +539,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-07-31T10:08:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T10:15:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T10:15:00.000Z"
       }
     },
     {
@@ -644,9 +559,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T10:15:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T10:15:00.000Z"
       }
     },
     {
@@ -660,21 +575,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-07-31T10:05:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T10:15:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T10:15:00.000Z"
       }
     },
     {
@@ -688,21 +593,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-07-31T10:02:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T10:15:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T10:15:00.000Z"
       }
     },
     {
@@ -718,9 +613,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -740,24 +635,15 @@
           "lineCode": "M-161",
           "lineName": "Barbate-Facinas-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-07-31T10:10:00.000Z",
+          "scheduledTime": "2026-08-01T10:10:00.000Z",
           "direction": 1,
           "stopType": 0
-        },
-        {
-          "lineId": "7",
-          "lineCode": "M-150",
-          "lineName": "Algeciras-Tarifa",
-          "destination": "Algeciras",
-          "scheduledTime": "2026-07-31T10:45:00.000Z",
-          "direction": 2,
-          "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -777,7 +663,7 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-07-31T10:30:00.000Z",
+          "scheduledTime": "2026-08-01T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -786,15 +672,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Algeciras",
-          "scheduledTime": "2026-07-31T10:30:00.000Z",
+          "scheduledTime": "2026-08-01T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -814,15 +700,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-07-31T10:03:00.000Z",
+          "scheduledTime": "2026-08-01T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -842,8 +728,17 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-07-31T10:45:00.000Z",
+          "scheduledTime": "2026-08-01T10:45:00.000Z",
           "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "11",
+          "lineCode": "M-230",
+          "lineName": "La Línea-San Roque",
+          "destination": "La Línea de la Concepción",
+          "scheduledTime": "2026-08-01T10:45:00.000Z",
+          "direction": 2,
           "stopType": 1
         },
         {
@@ -851,15 +746,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-07-31T11:00:00.000Z",
+          "scheduledTime": "2026-08-01T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -878,34 +773,16 @@
           "lineId": "40",
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
-          "destination": "ADRA",
-          "scheduledTime": "2026-07-31T10:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "40",
-          "lineCode": "M-380",
-          "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-07-31T10:48:00.000Z",
+          "scheduledTime": "2026-08-01T10:33:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "48",
-          "lineCode": "M-384",
-          "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
-          "destination": "ADRA",
-          "scheduledTime": "2026-07-31T10:51:00.000Z",
-          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -921,9 +798,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -939,9 +816,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -957,9 +834,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -975,9 +852,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T11:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T11:00:00.000Z"
       }
     },
     {
@@ -993,9 +870,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T12:30:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T12:30:00.000Z"
       }
     },
     {
@@ -1014,17 +891,17 @@
           "lineId": "278",
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-07-31T10:20:00.000Z",
-          "direction": 1,
+          "destination": "Jaén",
+          "scheduledTime": "2026-08-01T10:28:00.000Z",
+          "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-07-31T10:38:00.000Z",
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-08-01T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1033,60 +910,60 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-07-31T10:50:00.000Z",
+          "scheduledTime": "2026-08-01T10:50:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
+          "lineId": "279",
+          "lineCode": "M20-02",
+          "lineName": "Jaén - Jamilena, 2024",
+          "destination": "Jamilena",
+          "scheduledTime": "2026-08-01T11:25:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "279",
+          "lineCode": "M20-02",
+          "lineName": "Jaén - Jamilena, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-31T11:13:00.000Z",
+          "scheduledTime": "2026-08-01T11:43:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-07-31T11:20:00.000Z",
-          "direction": 1,
           "stopType": 0
         },
         {
           "lineId": "281",
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-07-31T11:43:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "288",
-          "lineCode": "M20-12",
-          "lineName": "Jaén - Escañuela, 2024",
-          "destination": "Escañuela",
-          "scheduledTime": "2026-07-31T11:55:00.000Z",
+          "destination": "Martos",
+          "scheduledTime": "2026-08-01T11:55:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "285",
-          "lineCode": "M20-08",
-          "lineName": "Jaén - Lopera, 2024",
-          "destination": "Torredonjimeno",
-          "scheduledTime": "2026-07-31T12:20:00.000Z",
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-08-01T12:13:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "280",
+          "lineCode": "M20-03",
+          "lineName": "Jaén - Villardompardo, 2024",
+          "destination": "Villardompardo",
+          "scheduledTime": "2026-08-01T12:25:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T12:30:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T12:30:00.000Z"
       }
     },
     {
@@ -1102,12 +979,12 @@
       "nucleus": "Torredonjimeno",
       "services": [
         {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-31T10:25:00.000Z",
-          "direction": 1,
+          "scheduledTime": "2026-08-01T10:15:00.000Z",
+          "direction": 2,
           "stopType": 0
         },
         {
@@ -1115,17 +992,8 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-07-31T10:33:00.000Z",
+          "scheduledTime": "2026-08-01T10:48:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-07-31T11:00:00.000Z",
-          "direction": 2,
           "stopType": 0
         },
         {
@@ -1133,51 +1001,33 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-07-31T11:03:00.000Z",
+          "scheduledTime": "2026-08-01T11:03:00.000Z",
           "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-08-01T12:00:00.000Z",
+          "direction": 2,
           "stopType": 0
         },
         {
           "lineId": "281",
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-07-31T11:30:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-07-31T11:33:00.000Z",
+          "scheduledTime": "2026-08-01T12:08:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "288",
-          "lineCode": "M20-12",
-          "lineName": "Jaén - Escañuela, 2024",
-          "destination": "Escañuela",
-          "scheduledTime": "2026-07-31T12:08:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-07-31T12:25:00.000Z",
-          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T12:30:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T12:30:00.000Z"
       }
     },
     {
@@ -1197,80 +1047,8 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-07-31T10:00:00.000Z",
+          "scheduledTime": "2026-08-01T10:00:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-07-31T10:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "73",
-          "lineCode": "M16-3",
-          "lineName": "Bailén - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-07-31T10:15:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-07-31T10:40:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-07-31T11:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-07-31T11:25:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-07-31T11:30:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "72",
-          "lineCode": "M16-2",
-          "lineName": "La Carolina - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-07-31T11:45:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-07-31T11:55:00.000Z",
-          "direction": 2,
           "stopType": 0
         },
         {
@@ -1278,15 +1056,24 @@
           "lineCode": "M15-7",
           "lineName": "Jaén - Andújar - Marmolejo",
           "destination": "Andújar",
-          "scheduledTime": "2026-07-31T12:25:00.000Z",
+          "scheduledTime": "2026-08-01T10:55:00.000Z",
           "direction": 1,
           "stopType": 1
+        },
+        {
+          "lineId": "203",
+          "lineCode": "M04-8",
+          "lineName": "Linares - Jaén",
+          "destination": "Mengíbar",
+          "scheduledTime": "2026-08-01T11:00:00.000Z",
+          "direction": 2,
+          "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T12:30:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T12:30:00.000Z"
       }
     },
     {
@@ -1305,52 +1092,25 @@
           "lineId": "17",
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-07-31T10:30:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-07-31T10:55:00.000Z",
+          "scheduledTime": "2026-08-01T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "35",
-          "lineCode": "M3-103",
-          "lineName": "Úbeda - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-07-31T11:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-07-31T11:30:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-07-31T11:55:00.000Z",
+          "lineId": "22",
+          "lineCode": "M1-21",
+          "lineName": "Torres - Jaén",
+          "destination": "Torres",
+          "scheduledTime": "2026-08-01T12:25:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T12:30:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T12:30:00.000Z"
       }
     },
     {
@@ -1366,9 +1126,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-08-01T02:39:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-02T02:39:00.000Z"
       }
     },
     {
@@ -1384,9 +1144,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-08-01T02:39:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-02T02:39:00.000Z"
       }
     },
     {
@@ -1402,9 +1162,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-08-01T02:39:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-02T02:39:00.000Z"
       }
     },
     {
@@ -1420,9 +1180,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-08-01T02:39:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-02T02:39:00.000Z"
       }
     },
     {
@@ -1438,9 +1198,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-08-01T02:39:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-02T02:39:00.000Z"
       }
     },
     {
@@ -1460,16 +1220,16 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-31T10:00:00.000Z",
+          "scheduledTime": "2026-08-01T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "13",
-          "lineCode": "M-303",
-          "lineName": "Huelva-Corrales-Ayamonte",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-31T10:04:00.000Z",
+          "scheduledTime": "2026-08-01T10:03:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1478,7 +1238,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-31T10:21:00.000Z",
+          "scheduledTime": "2026-08-01T10:21:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1487,7 +1247,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-31T10:42:00.000Z",
+          "scheduledTime": "2026-08-01T10:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1496,7 +1256,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-31T11:00:00.000Z",
+          "scheduledTime": "2026-08-01T11:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1505,17 +1265,8 @@
           "lineCode": "M-303",
           "lineName": "Huelva-Corrales-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-31T11:04:00.000Z",
+          "scheduledTime": "2026-08-01T11:04:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-31T11:11:00.000Z",
-          "direction": 1,
           "stopType": 0
         },
         {
@@ -1523,17 +1274,8 @@
           "lineCode": "M-902",
           "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-07-31T11:21:00.000Z",
+          "scheduledTime": "2026-08-01T11:21:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-31T11:41:00.000Z",
-          "direction": 1,
           "stopType": 0
         },
         {
@@ -1541,7 +1283,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-31T11:42:00.000Z",
+          "scheduledTime": "2026-08-01T11:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1550,7 +1292,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-31T11:44:00.000Z",
+          "scheduledTime": "2026-08-01T11:44:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1559,16 +1301,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-31T12:00:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "8",
-          "lineCode": "M-316",
-          "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
-          "destination": "VILLABLANCA",
-          "scheduledTime": "2026-07-31T12:36:00.000Z",
+          "scheduledTime": "2026-08-01T12:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1577,7 +1310,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-31T12:42:00.000Z",
+          "scheduledTime": "2026-08-01T12:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1586,17 +1319,8 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-07-31T13:00:00.000Z",
+          "scheduledTime": "2026-08-01T13:00:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-07-31T13:15:00.000Z",
-          "direction": 2,
           "stopType": 0
         },
         {
@@ -1604,7 +1328,16 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-31T13:21:00.000Z",
+          "scheduledTime": "2026-08-01T13:21:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "13",
+          "lineCode": "M-303",
+          "lineName": "Huelva-Corrales-Ayamonte",
+          "destination": "AYAMONTE",
+          "scheduledTime": "2026-08-01T13:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1613,24 +1346,15 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-07-31T13:42:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "69",
-          "lineCode": "M-905",
-          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-07-31T13:44:00.000Z",
+          "scheduledTime": "2026-08-01T13:42:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T14:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T14:00:00.000Z"
       }
     },
     {
@@ -1650,7 +1374,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-31T10:49:00.000Z",
+          "scheduledTime": "2026-08-01T10:49:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1659,43 +1383,16 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-31T11:20:00.000Z",
+          "scheduledTime": "2026-08-01T11:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-31T11:50:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-31T12:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-31T12:30:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "69",
-          "lineCode": "M-905",
-          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-07-31T13:20:00.000Z",
+          "scheduledTime": "2026-08-01T13:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1704,15 +1401,15 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-07-31T13:49:00.000Z",
+          "scheduledTime": "2026-08-01T13:49:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T14:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T14:00:00.000Z"
       }
     },
     {
@@ -1732,7 +1429,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-31T10:03:00.000Z",
+          "scheduledTime": "2026-08-01T10:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1741,7 +1438,7 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-31T10:14:00.000Z",
+          "scheduledTime": "2026-08-01T10:14:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1750,7 +1447,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-07-31T10:48:00.000Z",
+          "scheduledTime": "2026-08-01T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1759,17 +1456,8 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-31T11:03:00.000Z",
+          "scheduledTime": "2026-08-01T11:03:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "60",
-          "lineCode": "M-417",
-          "lineName": "Paterna-Torre Higuera",
-          "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-07-31T11:18:00.000Z",
-          "direction": 2,
           "stopType": 0
         },
         {
@@ -1777,7 +1465,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-07-31T11:48:00.000Z",
+          "scheduledTime": "2026-08-01T11:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1786,25 +1474,16 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-31T12:03:00.000Z",
+          "scheduledTime": "2026-08-01T12:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "48",
-          "lineCode": "M-405",
-          "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
+          "lineId": "50",
+          "lineCode": "M-407",
+          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-07-31T12:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "70",
-          "lineCode": "M-906",
-          "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
-          "destination": "ROCIANA DEL CONDADO",
-          "scheduledTime": "2026-07-31T12:43:00.000Z",
+          "scheduledTime": "2026-08-01T12:47:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1813,7 +1492,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-07-31T12:48:00.000Z",
+          "scheduledTime": "2026-08-01T12:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1822,34 +1501,34 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-07-31T13:03:00.000Z",
+          "scheduledTime": "2026-08-01T13:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "60",
-          "lineCode": "M-417",
-          "lineName": "Paterna-Torre Higuera",
-          "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-07-31T13:48:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "ALMONTE",
-          "scheduledTime": "2026-07-31T13:48:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "48",
-          "lineCode": "M-405",
-          "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
+          "lineId": "50",
+          "lineCode": "M-407",
+          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
           "destination": "HUELVA",
-          "scheduledTime": "2026-07-31T13:52:00.000Z",
+          "scheduledTime": "2026-08-01T13:47:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "ALMONTE",
+          "scheduledTime": "2026-08-01T13:48:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "60",
+          "lineCode": "M-417",
+          "lineName": "Paterna-Torre Higuera",
+          "destination": "BOLLULLOS PAR DEL CONDADO",
+          "scheduledTime": "2026-08-01T13:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1858,15 +1537,15 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "HINOJOS",
-          "scheduledTime": "2026-07-31T13:58:00.000Z",
+          "scheduledTime": "2026-08-01T13:58:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T14:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T14:00:00.000Z"
       }
     },
     {
@@ -1882,9 +1561,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T14:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T14:00:00.000Z"
       }
     },
     {
@@ -1900,9 +1579,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-07-31T07:51:52.300Z",
-        "startTime": "2026-07-31T10:00:00.000Z",
-        "endTime": "2026-07-31T14:00:00.000Z"
+        "requestedAt": "2026-08-01T07:28:24.372Z",
+        "startTime": "2026-08-01T10:00:00.000Z",
+        "endTime": "2026-08-01T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:43.561Z",
+    "generatedAt": "2026-08-01T07:28:16.854Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:43.561Z",
+    "generatedAt": "2026-08-01T07:28:16.854Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:43.561Z",
+    "generatedAt": "2026-08-01T07:28:16.854Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:43.561Z",
+    "generatedAt": "2026-08-01T07:28:16.854Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:43.561Z",
+    "generatedAt": "2026-08-01T07:28:16.854Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:43.561Z",
+    "generatedAt": "2026-08-01T07:28:16.854Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:43.561Z",
+    "generatedAt": "2026-08-01T07:28:16.854Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:43.561Z",
+    "generatedAt": "2026-08-01T07:28:16.854Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:43.561Z",
+    "generatedAt": "2026-08-01T07:28:16.854Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-07-31T07:51:43.561Z",
+    "generatedAt": "2026-08-01T07:28:16.854Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-08-01 07:29 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Refreshed transit catalog and stop-directory information for August 1, 2026.
  * Updated stop service schedules, departures, routes, destinations, directions, and stop availability.
  * Added and removed services where current transit data required changes.
  * Updated service-news indicators for select routes to reflect their latest status.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->