### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:20.352Z",
+    "generatedAt": "2026-08-02T07:32:30.995Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:24.372Z",
+    "generatedAt": "2026-08-02T07:32:34.226Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -19,9 +19,9 @@
       "nucleus": "FUENTE DEL REY (Dos Hermanas) zonaC",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -37,28 +37,28 @@
       "nucleus": "ESPARTINAS",
       "services": [
         {
-          "lineId": "284",
-          "lineCode": "1666",
-          "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-08-01T10:31:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
           "lineId": "295",
           "lineCode": "1681",
           "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-08-01T10:57:00.000Z",
+          "scheduledTime": "2026-08-02T10:27:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "284",
+          "lineCode": "1666",
+          "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-08-02T10:31:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -74,9 +74,9 @@
       "nucleus": "SANTIPONCE",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -92,9 +92,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -114,7 +114,7 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-08-01T10:04:00.000Z",
+          "scheduledTime": "2026-08-02T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -123,15 +123,15 @@
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-08-01T10:04:00.000Z",
+          "scheduledTime": "2026-08-02T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -151,7 +151,7 @@
           "lineCode": "M-560",
           "lineName": "Rota-Jerez De La Frontera",
           "destination": "Rota",
-          "scheduledTime": "2026-08-01T10:30:00.000Z",
+          "scheduledTime": "2026-08-02T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -160,15 +160,15 @@
           "lineCode": "M-560",
           "lineName": "Rota-Jerez De La Frontera",
           "destination": "Jerez",
-          "scheduledTime": "2026-08-01T11:00:00.000Z",
+          "scheduledTime": "2026-08-02T11:00:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -184,9 +184,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -206,7 +206,7 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-08-01T10:05:00.000Z",
+          "scheduledTime": "2026-08-02T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -215,7 +215,7 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Jerez",
-          "scheduledTime": "2026-08-01T10:05:00.000Z",
+          "scheduledTime": "2026-08-02T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -224,7 +224,7 @@
           "lineCode": "M-965",
           "lineName": "Chipiona-Sanlúcar De Barrameda (Sevilla/Utrera)",
           "destination": "Sanlúcar de Barrameda",
-          "scheduledTime": "2026-08-01T10:05:00.000Z",
+          "scheduledTime": "2026-08-02T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -233,7 +233,7 @@
           "lineCode": "M-965",
           "lineName": "Chipiona-Sanlúcar De Barrameda (Sevilla/Utrera)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-08-01T10:11:00.000Z",
+          "scheduledTime": "2026-08-02T10:11:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -242,15 +242,15 @@
           "lineCode": "M-561",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
           "destination": "Jerez",
-          "scheduledTime": "2026-08-01T10:45:00.000Z",
+          "scheduledTime": "2026-08-02T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -266,9 +266,9 @@
       "nucleus": "Chiclana",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -288,7 +288,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-08-01T10:10:00.000Z",
+          "scheduledTime": "2026-08-02T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -297,15 +297,33 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-08-01T10:21:00.000Z",
+          "scheduledTime": "2026-08-02T10:21:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "9",
+          "lineCode": "M-031",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
+          "destination": "Puerto Real",
+          "scheduledTime": "2026-08-02T10:31:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "9",
+          "lineCode": "M-031",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
+          "destination": "Cádiz",
+          "scheduledTime": "2026-08-02T10:52:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -325,7 +343,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-08-01T10:21:00.000Z",
+          "scheduledTime": "2026-08-02T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -334,15 +352,15 @@
           "lineCode": "0226",
           "lineName": "Granada - P.Puente - Zujaira",
           "destination": "Zujaira",
-          "scheduledTime": "2026-08-01T11:49:00.000Z",
+          "scheduledTime": "2026-08-02T11:49:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T12:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T12:00:00.000Z"
       }
     },
     {
@@ -362,7 +380,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Centro Penitenciario de Albolote",
-          "scheduledTime": "2026-08-01T10:15:00.000Z",
+          "scheduledTime": "2026-08-02T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -371,7 +389,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Granada",
-          "scheduledTime": "2026-08-01T11:09:00.000Z",
+          "scheduledTime": "2026-08-02T10:54:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -380,15 +398,15 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Centro Penitenciario de Albolote",
-          "scheduledTime": "2026-08-01T11:45:00.000Z",
+          "scheduledTime": "2026-08-02T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T12:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T12:00:00.000Z"
       }
     },
     {
@@ -408,24 +426,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-08-01T10:27:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1119",
-          "lineCode": "0242",
-          "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
-          "destination": "Láchar",
-          "scheduledTime": "2026-08-01T11:27:00.000Z",
+          "scheduledTime": "2026-08-02T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T12:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T12:00:00.000Z"
       }
     },
     {
@@ -441,9 +450,9 @@
       "nucleus": "Cijuela",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T12:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T12:00:00.000Z"
       }
     },
     {
@@ -463,7 +472,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-08-01T10:00:00.000Z",
+          "scheduledTime": "2026-08-02T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -472,7 +481,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-08-01T10:01:00.000Z",
+          "scheduledTime": "2026-08-02T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -481,7 +490,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-08-01T10:45:00.000Z",
+          "scheduledTime": "2026-08-02T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -490,7 +499,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-08-01T11:15:00.000Z",
+          "scheduledTime": "2026-08-02T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -499,15 +508,15 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-08-01T11:31:00.000Z",
+          "scheduledTime": "2026-08-02T11:31:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T12:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T12:00:00.000Z"
       }
     },
     {
@@ -523,9 +532,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T10:15:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T10:15:00.000Z"
       }
     },
     {
@@ -541,9 +550,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T10:15:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T10:15:00.000Z"
       }
     },
     {
@@ -559,9 +568,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T10:15:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T10:15:00.000Z"
       }
     },
     {
@@ -577,9 +586,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T10:15:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T10:15:00.000Z"
       }
     },
     {
@@ -595,9 +604,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T10:15:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T10:15:00.000Z"
       }
     },
     {
@@ -613,9 +622,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -635,15 +644,15 @@
           "lineCode": "M-161",
           "lineName": "Barbate-Facinas-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-08-01T10:10:00.000Z",
+          "scheduledTime": "2026-08-02T10:10:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -662,25 +671,25 @@
           "lineId": "1",
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
-          "destination": "Los Barrios",
-          "scheduledTime": "2026-08-01T10:30:00.000Z",
-          "direction": 2,
+          "destination": "Algeciras",
+          "scheduledTime": "2026-08-02T10:30:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
           "lineId": "1",
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
-          "destination": "Algeciras",
-          "scheduledTime": "2026-08-01T10:30:00.000Z",
-          "direction": 1,
+          "destination": "Los Barrios",
+          "scheduledTime": "2026-08-02T10:30:00.000Z",
+          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -700,15 +709,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-08-01T10:03:00.000Z",
+          "scheduledTime": "2026-08-02T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -728,7 +737,7 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-08-01T10:45:00.000Z",
+          "scheduledTime": "2026-08-02T10:45:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -737,7 +746,7 @@
           "lineCode": "M-230",
           "lineName": "La Línea-San Roque",
           "destination": "La Línea de la Concepción",
-          "scheduledTime": "2026-08-01T10:45:00.000Z",
+          "scheduledTime": "2026-08-02T10:45:00.000Z",
           "direction": 2,
           "stopType": 1
         },
@@ -746,15 +755,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-08-01T11:00:00.000Z",
+          "scheduledTime": "2026-08-02T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -774,15 +783,15 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-08-01T10:33:00.000Z",
+          "scheduledTime": "2026-08-02T10:33:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -798,9 +807,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -816,9 +825,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -834,9 +843,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -852,9 +861,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T11:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T11:00:00.000Z"
       }
     },
     {
@@ -870,9 +879,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T12:30:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T12:30:00.000Z"
       }
     },
     {
@@ -888,11 +897,11 @@
       "nucleus": "Torredelcampo",
       "services": [
         {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
+          "lineId": "289",
+          "lineCode": "M20-13",
+          "lineName": "Jaén - Jamilena - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-01T10:28:00.000Z",
+          "scheduledTime": "2026-08-02T10:33:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -901,7 +910,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-08-01T10:35:00.000Z",
+          "scheduledTime": "2026-08-02T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -909,27 +918,18 @@
           "lineId": "283",
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
-          "destination": "Torredonjimeno",
-          "scheduledTime": "2026-08-01T10:50:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "279",
-          "lineCode": "M20-02",
-          "lineName": "Jaén - Jamilena, 2024",
-          "destination": "Jamilena",
-          "scheduledTime": "2026-08-01T11:25:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "279",
-          "lineCode": "M20-02",
-          "lineName": "Jaén - Jamilena, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-01T11:43:00.000Z",
+          "scheduledTime": "2026-08-02T10:41:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "283",
+          "lineCode": "M20-06",
+          "lineName": "Jaén - Córdoba (Ruta), 2024",
+          "destination": "Torredonjimeno",
+          "scheduledTime": "2026-08-02T11:20:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
@@ -937,7 +937,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-08-01T11:55:00.000Z",
+          "scheduledTime": "2026-08-02T11:55:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -946,24 +946,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-01T12:13:00.000Z",
+          "scheduledTime": "2026-08-02T12:28:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "280",
-          "lineCode": "M20-03",
-          "lineName": "Jaén - Villardompardo, 2024",
-          "destination": "Villardompardo",
-          "scheduledTime": "2026-08-01T12:25:00.000Z",
-          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T12:30:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T12:30:00.000Z"
       }
     },
     {
@@ -979,11 +970,20 @@
       "nucleus": "Torredonjimeno",
       "services": [
         {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
+          "lineId": "289",
+          "lineCode": "M20-13",
+          "lineName": "Jaén - Jamilena - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-01T10:15:00.000Z",
+          "scheduledTime": "2026-08-02T10:15:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "283",
+          "lineCode": "M20-06",
+          "lineName": "Jaén - Córdoba (Ruta), 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-08-02T10:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -992,7 +992,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-08-01T10:48:00.000Z",
+          "scheduledTime": "2026-08-02T10:48:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1001,7 +1001,16 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-08-01T11:03:00.000Z",
+          "scheduledTime": "2026-08-02T11:33:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "281",
+          "lineCode": "M20-04",
+          "lineName": "Jaén - Alcaudete, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-08-02T12:08:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1010,24 +1019,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-01T12:00:00.000Z",
+          "scheduledTime": "2026-08-02T12:15:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "281",
-          "lineCode": "M20-04",
-          "lineName": "Jaén - Alcaudete, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-08-01T12:08:00.000Z",
-          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T12:30:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T12:30:00.000Z"
       }
     },
     {
@@ -1046,34 +1046,16 @@
           "lineId": "203",
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-08-01T10:00:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "276",
-          "lineCode": "M15-7",
-          "lineName": "Jaén - Andújar - Marmolejo",
-          "destination": "Andújar",
-          "scheduledTime": "2026-08-01T10:55:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-08-01T11:00:00.000Z",
+          "scheduledTime": "2026-08-02T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T12:30:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T12:30:00.000Z"
       }
     },
     {
@@ -1087,30 +1069,11 @@
       },
       "municipality": "Mancha Real",
       "nucleus": "Mancha Real",
-      "services": [
-        {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-08-01T11:55:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "22",
-          "lineCode": "M1-21",
-          "lineName": "Torres - Jaén",
-          "destination": "Torres",
-          "scheduledTime": "2026-08-01T12:25:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T12:30:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T12:30:00.000Z"
       }
     },
     {
@@ -1126,9 +1089,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-02T02:39:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-03T02:39:00.000Z"
       }
     },
     {
@@ -1144,9 +1107,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-02T02:39:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-03T02:39:00.000Z"
       }
     },
     {
@@ -1162,9 +1125,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-02T02:39:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-03T02:39:00.000Z"
       }
     },
     {
@@ -1180,9 +1143,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-02T02:39:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-03T02:39:00.000Z"
       }
     },
     {
@@ -1198,9 +1161,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-02T02:39:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-03T02:39:00.000Z"
       }
     },
     {
@@ -1220,7 +1183,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-08-01T10:00:00.000Z",
+          "scheduledTime": "2026-08-02T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1229,17 +1192,8 @@
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-01T10:03:00.000Z",
+          "scheduledTime": "2026-08-02T10:03:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "69",
-          "lineCode": "M-905",
-          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-01T10:21:00.000Z",
-          "direction": 1,
           "stopType": 0
         },
         {
@@ -1247,7 +1201,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-08-01T10:42:00.000Z",
+          "scheduledTime": "2026-08-02T10:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1256,26 +1210,17 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-08-01T11:00:00.000Z",
+          "scheduledTime": "2026-08-02T11:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "13",
-          "lineCode": "M-303",
-          "lineName": "Huelva-Corrales-Ayamonte",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-08-01T11:04:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "66",
-          "lineCode": "M-902",
-          "lineName": "Ayamonte-Huelva-Sevilla",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-08-01T11:21:00.000Z",
-          "direction": 2,
+          "scheduledTime": "2026-08-02T11:22:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
@@ -1283,7 +1228,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-08-01T11:42:00.000Z",
+          "scheduledTime": "2026-08-02T11:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1292,7 +1237,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-01T11:44:00.000Z",
+          "scheduledTime": "2026-08-02T11:44:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1301,7 +1246,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-08-01T12:00:00.000Z",
+          "scheduledTime": "2026-08-02T12:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1310,7 +1255,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-08-01T12:42:00.000Z",
+          "scheduledTime": "2026-08-02T12:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1319,25 +1264,16 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-08-01T13:00:00.000Z",
+          "scheduledTime": "2026-08-02T13:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "69",
-          "lineCode": "M-905",
-          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-01T13:21:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "13",
-          "lineCode": "M-303",
-          "lineName": "Huelva-Corrales-Ayamonte",
+          "lineId": "5",
+          "lineCode": "M-310",
+          "lineName": "Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-08-01T13:36:00.000Z",
+          "scheduledTime": "2026-08-02T13:38:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1346,15 +1282,15 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-08-01T13:42:00.000Z",
+          "scheduledTime": "2026-08-02T13:42:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T14:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T14:00:00.000Z"
       }
     },
     {
@@ -1373,17 +1309,8 @@
           "lineId": "69",
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-01T10:49:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "69",
-          "lineCode": "M-905",
-          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-01T11:20:00.000Z",
+          "scheduledTime": "2026-08-02T11:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1391,25 +1318,25 @@
           "lineId": "76",
           "lineCode": "M-912",
           "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-08-01T13:20:00.000Z",
-          "direction": 2,
+          "destination": "AYAMONTE",
+          "scheduledTime": "2026-08-02T12:00:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "69",
-          "lineCode": "M-905",
-          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-01T13:49:00.000Z",
-          "direction": 1,
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "destination": "HUELVA",
+          "scheduledTime": "2026-08-02T13:20:00.000Z",
+          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T14:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T14:00:00.000Z"
       }
     },
     {
@@ -1429,7 +1356,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-01T10:03:00.000Z",
+          "scheduledTime": "2026-08-02T10:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1438,7 +1365,7 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-01T10:14:00.000Z",
+          "scheduledTime": "2026-08-02T10:14:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1447,7 +1374,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-08-01T10:48:00.000Z",
+          "scheduledTime": "2026-08-02T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1456,7 +1383,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-01T11:03:00.000Z",
+          "scheduledTime": "2026-08-02T11:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1465,7 +1392,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-08-01T11:48:00.000Z",
+          "scheduledTime": "2026-08-02T11:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1474,16 +1401,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-01T12:03:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "50",
-          "lineCode": "M-407",
-          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
-          "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-08-01T12:47:00.000Z",
+          "scheduledTime": "2026-08-02T12:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1492,7 +1410,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-08-01T12:48:00.000Z",
+          "scheduledTime": "2026-08-02T12:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1501,17 +1419,8 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-01T13:03:00.000Z",
+          "scheduledTime": "2026-08-02T13:03:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "50",
-          "lineCode": "M-407",
-          "lineName": "Huelva-Bonares-Almonte-Bollullos Par Del Condado",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-08-01T13:47:00.000Z",
-          "direction": 2,
           "stopType": 0
         },
         {
@@ -1519,7 +1428,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-08-01T13:48:00.000Z",
+          "scheduledTime": "2026-08-02T13:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1528,7 +1437,7 @@
           "lineCode": "M-417",
           "lineName": "Paterna-Torre Higuera",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-08-01T13:48:00.000Z",
+          "scheduledTime": "2026-08-02T13:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1537,15 +1446,15 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "HINOJOS",
-          "scheduledTime": "2026-08-01T13:58:00.000Z",
+          "scheduledTime": "2026-08-02T13:58:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T14:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T14:00:00.000Z"
       }
     },
     {
@@ -1561,9 +1470,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T14:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T14:00:00.000Z"
       }
     },
     {
@@ -1579,9 +1488,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-01T07:28:24.372Z",
-        "startTime": "2026-08-01T10:00:00.000Z",
-        "endTime": "2026-08-01T14:00:00.000Z"
+        "requestedAt": "2026-08-02T07:32:34.226Z",
+        "startTime": "2026-08-02T10:00:00.000Z",
+        "endTime": "2026-08-02T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:16.854Z",
+    "generatedAt": "2026-08-02T07:32:27.886Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:16.854Z",
+    "generatedAt": "2026-08-02T07:32:27.886Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:16.854Z",
+    "generatedAt": "2026-08-02T07:32:27.886Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:16.854Z",
+    "generatedAt": "2026-08-02T07:32:27.886Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:16.854Z",
+    "generatedAt": "2026-08-02T07:32:27.886Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:16.854Z",
+    "generatedAt": "2026-08-02T07:32:27.886Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:16.854Z",
+    "generatedAt": "2026-08-02T07:32:27.886Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:16.854Z",
+    "generatedAt": "2026-08-02T07:32:27.886Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:16.854Z",
+    "generatedAt": "2026-08-02T07:32:27.886Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-01T07:28:16.854Z",
+    "generatedAt": "2026-08-02T07:32:27.886Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-08-02 07:33 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Refreshed catalog and stop-directory timestamps for August 2, 2026.
  * Regenerated the latest stop-service snapshot with updated schedules, departure times, route details, and service availability across multiple areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->