### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,
@@ -243,7 +243,7 @@
         "NEX Continental Holdings",
         "S.L.U."
       ],
-      "hasNews": true,
+      "hasNews": false,
       "concession": null,
       "notes": null,
       "modeNotes": null,
@@ -567,7 +567,7 @@
         "Empresa Liñan",
         "S.L."
       ],
-      "hasNews": true,
+      "hasNews": false,
       "concession": null,
       "notes": null,
       "modeNotes": null,
@@ -642,7 +642,7 @@
         "Empresa Liñan",
         "S.L."
       ],
-      "hasNews": true,
+      "hasNews": false,
       "concession": null,
       "notes": null,
       "modeNotes": null,
@@ -792,7 +792,7 @@
         "NEX Continental Holdings",
         "S.L.U."
       ],
-      "hasNews": true,
+      "hasNews": false,
       "concession": null,
       "notes": null,
       "modeNotes": null,
@@ -817,7 +817,7 @@
         "NEX Continental Holdings",
         "S.L.U."
       ],
-      "hasNews": true,
+      "hasNews": false,
       "concession": null,
       "notes": null,
       "modeNotes": null,
@@ -1517,7 +1517,7 @@
         "Alsa Granada Airport",
         "S.L."
       ],
-      "hasNews": true,
+      "hasNews": false,
       "concession": null,
       "notes": null,
       "modeNotes": null,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,
     "consortiumName": "Área de Málaga",
-    "itemCount": 101
+    "itemCount": 110
   },
   "lines": [
     {
@@ -482,6 +482,31 @@
       "inboundPath": []
     },
     {
+      "id": "198",
+      "code": "M-410",
+      "name": "Cártama -Feria De Málaga (del 15 al 22 de agosto)",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Avanza Movilidad Integral",
+        "S.L."
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
       "id": "90",
       "code": "M-136",
       "name": "Cártama-Alhaurín De La Torre-Plaza Mayor-Los Álamos",
@@ -607,6 +632,31 @@
       "inboundPath": []
     },
     {
+      "id": "294",
+      "code": "M-429",
+      "name": "Coín-Alhaurín el Grande-Feria de Málaga 15 al 22 agosto",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Avanza Movilidad Integral",
+        "S.L."
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
       "id": "274",
       "code": "M-167",
       "name": "Coín-Alhaurín el Grande-Málaga",
@@ -685,6 +735,106 @@
       "id": "227",
       "code": "M-223",
       "name": "Entrerríos-Las Lagunas-Fuengirola",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Avanza Movilidad Integral",
+        "S.L."
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "28",
+      "code": "M-424",
+      "name": "Fería de Málaga-Alh.Torre-Pinos Alh. 15 al 22 agosto",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Avanza Movilidad Integral",
+        "S.L."
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "197",
+      "code": "M-451",
+      "name": "Feria de Málaga-Colmenar-Riogordo 15 al 22 agosto",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Nex Continental Holdings",
+        "S.L.U."
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "29",
+      "code": "M-428",
+      "name": "Feria de Málaga-Rincón de la Victoria 15 al 22 agosto",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Avanza Movilidad Integral",
+        "S.L."
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "26",
+      "code": "M-421",
+      "name": "Feria De Málaga-Torremolinos-Benalmádena Costa 15 al 22 agosto",
       "mode": "Autobús",
       "modeId": "1",
       "operators": [
@@ -909,6 +1059,31 @@
       "id": "15",
       "code": "M-127",
       "name": "Las Lagunas-Estación De Autobuses",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Avanza Movilidad Integral",
+        "S.L."
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "212",
+      "code": "M-426",
+      "name": "Las Lagunas-Fuengirola-Feria de Málaga 15 al 22 agosto",
       "mode": "Autobús",
       "modeId": "1",
       "operators": [
@@ -2375,6 +2550,30 @@
       "inboundPath": []
     },
     {
+      "id": "235",
+      "code": "M-430",
+      "name": "Valle de Abdalajís-Álora-Pizarra-Feria de Málaga (del 15 al 22 de agosto)",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Damas S.A. e Interurbana de Autobuses S.A."
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
       "id": "233",
       "code": "M-540",
       "name": "Valle de Abdalajís-Álora-Pizarra-Los Álamos",
@@ -2476,6 +2675,31 @@
       "id": "146",
       "code": "M-550",
       "name": "Villanueva de la Concepción-Casabermeja-El Palo",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Automóviles Mérida",
+        "S.L."
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "150",
+      "code": "M-450",
+      "name": "Vva.Concepción-Casabermeja-Feria de Málaga 15 al 22 agosto",
       "mode": "Autobús",
       "modeId": "1",
       "operators": [

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,
     "consortiumName": "Área de Jaén",
-    "itemCount": 34
+    "itemCount": 35
   },
   "lines": [
     {
@@ -441,6 +441,31 @@
       "operators": [
         "Transportes Romero",
         "S.L."
+      ],
+      "hasNews": false,
+      "concession": null,
+      "notes": null,
+      "modeNotes": null,
+      "accessibility": null,
+      "thickness": null,
+      "color": null,
+      "outboundThermometerUrl": null,
+      "inboundThermometerUrl": null,
+      "hasOutbound": false,
+      "hasInbound": false,
+      "path": [],
+      "outboundPath": [],
+      "inboundPath": []
+    },
+    {
+      "id": "282",
+      "code": "M20-05",
+      "name": "Jaén - Martos (Directo), 2024",
+      "mode": "Autobús",
+      "modeId": "1",
+      "operators": [
+        "Autocares Samar",
+        "S.A."
       ],
       "hasNews": false,
       "concession": null,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:36.773Z",
+    "generatedAt": "2026-08-09T05:47:28.202Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:42.150Z",
+    "generatedAt": "2026-08-09T05:47:31.648Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -17,21 +17,11 @@
       },
       "municipality": "DOS HERMANAS",
       "nucleus": "FUENTE DEL REY (Dos Hermanas) zonaC",
-      "services": [
-        {
-          "lineId": "242",
-          "lineCode": "1320",
-          "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-08-07T10:07:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -47,37 +37,28 @@
       "nucleus": "ESPARTINAS",
       "services": [
         {
-          "lineId": "284",
-          "lineCode": "1666",
-          "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-08-07T10:01:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
           "lineId": "295",
           "lineCode": "1681",
           "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-08-07T10:42:00.000Z",
+          "scheduledTime": "2026-08-09T10:27:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "290",
-          "lineCode": "1020",
-          "lineName": "M-102A Circular Aljarafe (sentido A)",
-          "destination": "SANLUCAR LA MAYOR",
-          "scheduledTime": "2026-08-07T10:46:00.000Z",
+          "lineId": "284",
+          "lineCode": "1666",
+          "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
+          "destination": "SEVILLA",
+          "scheduledTime": "2026-08-09T10:31:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -91,30 +72,11 @@
       },
       "municipality": "SANTIPONCE",
       "nucleus": "SANTIPONCE",
-      "services": [
-        {
-          "lineId": "287",
-          "lineCode": "1720",
-          "lineName": "M-170A Santiponce - Sevilla",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-08-07T10:02:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "1720",
-          "lineName": "M-170A Santiponce - Sevilla",
-          "destination": "SEVILLA",
-          "scheduledTime": "2026-08-07T10:32:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -130,9 +92,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -152,7 +114,7 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-08-07T10:04:00.000Z",
+          "scheduledTime": "2026-08-09T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -161,24 +123,15 @@
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-08-07T10:04:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "232",
-          "lineCode": "1100",
-          "lineName": "M-110 La Algaba - Sevilla",
-          "destination": "LA ALGABA",
-          "scheduledTime": "2026-08-07T10:34:00.000Z",
+          "scheduledTime": "2026-08-09T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -198,15 +151,24 @@
           "lineCode": "M-560",
           "lineName": "Rota-Jerez De La Frontera",
           "destination": "Rota",
-          "scheduledTime": "2026-08-07T10:00:00.000Z",
+          "scheduledTime": "2026-08-09T10:30:00.000Z",
           "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "32",
+          "lineCode": "M-560",
+          "lineName": "Rota-Jerez De La Frontera",
+          "destination": "Jerez",
+          "scheduledTime": "2026-08-09T11:00:00.000Z",
+          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -222,9 +184,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -240,11 +202,11 @@
       "nucleus": "Sanlúcar de Barrameda",
       "services": [
         {
-          "lineId": "225",
-          "lineCode": "M-967",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
+          "lineId": "163",
+          "lineCode": "M-960",
+          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-08-07T10:05:00.000Z",
+          "scheduledTime": "2026-08-09T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -253,26 +215,26 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Jerez",
-          "scheduledTime": "2026-08-07T10:05:00.000Z",
+          "scheduledTime": "2026-08-09T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "225",
-          "lineCode": "M-967",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
+          "lineId": "230",
+          "lineCode": "M-965",
+          "lineName": "Chipiona-Sanlúcar De Barrameda (Sevilla/Utrera)",
+          "destination": "Sanlúcar de Barrameda",
+          "scheduledTime": "2026-08-09T10:05:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "230",
+          "lineCode": "M-965",
+          "lineName": "Chipiona-Sanlúcar De Barrameda (Sevilla/Utrera)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-08-07T10:28:00.000Z",
+          "scheduledTime": "2026-08-09T10:11:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "165",
-          "lineCode": "M-962",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-San Fernando (Por Puerto Real Y Hospital)",
-          "destination": "San Fernando",
-          "scheduledTime": "2026-08-07T10:35:00.000Z",
-          "direction": 1,
           "stopType": 0
         },
         {
@@ -280,24 +242,15 @@
           "lineCode": "M-561",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
           "destination": "Jerez",
-          "scheduledTime": "2026-08-07T10:45:00.000Z",
+          "scheduledTime": "2026-08-09T10:45:00.000Z",
           "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "167",
-          "lineCode": "M-964",
-          "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
-          "destination": "Chipiona",
-          "scheduledTime": "2026-08-07T10:50:00.000Z",
-          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -311,30 +264,11 @@
       },
       "municipality": "Chiclana",
       "nucleus": "Chiclana",
-      "services": [
-        {
-          "lineId": "26",
-          "lineCode": "M-230",
-          "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
-          "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-08-07T10:16:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "26",
-          "lineCode": "M-230",
-          "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
-          "destination": "Chiclana",
-          "scheduledTime": "2026-08-07T10:44:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -353,17 +287,8 @@
           "lineId": "6",
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-08-07T10:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-08-07T10:10:00.000Z",
+          "scheduledTime": "2026-08-09T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -372,25 +297,7 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-08-07T10:21:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-08-07T10:35:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
-          "destination": "Cádiz",
-          "scheduledTime": "2026-08-07T10:40:00.000Z",
+          "scheduledTime": "2026-08-09T10:21:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -399,24 +306,24 @@
           "lineCode": "M-031",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
           "destination": "Puerto Real",
-          "scheduledTime": "2026-08-07T10:51:00.000Z",
+          "scheduledTime": "2026-08-09T10:31:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "6",
-          "lineCode": "M-030",
-          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
+          "lineId": "9",
+          "lineCode": "M-031",
+          "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
           "destination": "Cádiz",
-          "scheduledTime": "2026-08-07T11:00:00.000Z",
+          "scheduledTime": "2026-08-09T10:52:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -436,33 +343,24 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-08-07T10:21:00.000Z",
+          "scheduledTime": "2026-08-09T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
         {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-08-07T11:06:00.000Z",
-          "direction": 1,
-          "stopType": 1
-        },
-        {
-          "lineId": "991",
-          "lineCode": "0225",
-          "lineName": "Granada - P.Puente",
-          "destination": "Pinos Puente",
-          "scheduledTime": "2026-08-07T11:51:00.000Z",
+          "lineId": "992",
+          "lineCode": "0226",
+          "lineName": "Granada - P.Puente - Zujaira",
+          "destination": "Zujaira",
+          "scheduledTime": "2026-08-09T11:49:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T12:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T12:00:00.000Z"
       }
     },
     {
@@ -481,17 +379,8 @@
           "lineId": "1032",
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
-          "destination": "Granada",
-          "scheduledTime": "2026-08-07T10:39:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "710",
-          "lineCode": "0318",
-          "lineName": "Granada - Colomera",
-          "destination": "Cerro Cauro",
-          "scheduledTime": "2026-08-07T10:41:00.000Z",
+          "destination": "Centro Penitenciario de Albolote",
+          "scheduledTime": "2026-08-09T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -499,16 +388,25 @@
           "lineId": "1032",
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
-          "destination": "Parque del Cubillas",
-          "scheduledTime": "2026-08-07T11:30:00.000Z",
+          "destination": "Granada",
+          "scheduledTime": "2026-08-09T10:54:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "1032",
+          "lineCode": "0117",
+          "lineName": "Granada - P.Cubillas",
+          "destination": "Centro Penitenciario de Albolote",
+          "scheduledTime": "2026-08-09T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T12:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T12:00:00.000Z"
       }
     },
     {
@@ -524,37 +422,19 @@
       "nucleus": "Chauchina",
       "services": [
         {
-          "lineId": "868",
-          "lineCode": "0241",
-          "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
-          "destination": "Cijuela",
-          "scheduledTime": "2026-08-07T10:26:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
           "lineId": "1119",
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-08-07T11:27:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "1119",
-          "lineCode": "0242",
-          "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
-          "destination": "Láchar",
-          "scheduledTime": "2026-08-07T11:57:00.000Z",
+          "scheduledTime": "2026-08-09T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T12:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T12:00:00.000Z"
       }
     },
     {
@@ -568,21 +448,11 @@
       },
       "municipality": "Cijuela",
       "nucleus": "Cijuela",
-      "services": [
-        {
-          "lineId": "877",
-          "lineCode": "0340",
-          "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
-          "destination": "Granada",
-          "scheduledTime": "2026-08-07T11:01:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T12:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T12:00:00.000Z"
       }
     },
     {
@@ -602,7 +472,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-08-07T10:00:00.000Z",
+          "scheduledTime": "2026-08-09T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -611,7 +481,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-08-07T10:01:00.000Z",
+          "scheduledTime": "2026-08-09T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -620,7 +490,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-08-07T10:45:00.000Z",
+          "scheduledTime": "2026-08-09T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -629,7 +499,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-08-07T11:15:00.000Z",
+          "scheduledTime": "2026-08-09T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -638,15 +508,15 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-08-07T11:46:00.000Z",
+          "scheduledTime": "2026-08-09T11:31:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T12:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T12:00:00.000Z"
       }
     },
     {
@@ -660,21 +530,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-08-07T10:11:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T10:15:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T10:15:00.000Z"
       }
     },
     {
@@ -688,21 +548,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-08-07T10:08:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T10:15:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T10:15:00.000Z"
       }
     },
     {
@@ -718,9 +568,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T10:15:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T10:15:00.000Z"
       }
     },
     {
@@ -734,21 +584,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-08-07T10:05:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T10:15:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T10:15:00.000Z"
       }
     },
     {
@@ -762,21 +602,11 @@
       },
       "municipality": "Málaga",
       "nucleus": "Ventorrillo de Mayo",
-      "services": [
-        {
-          "lineId": "99",
-          "lineCode": "M-250",
-          "lineName": "Málaga-Almogía",
-          "destination": "Málaga",
-          "scheduledTime": "2026-08-07T10:02:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T10:15:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T10:15:00.000Z"
       }
     },
     {
@@ -792,9 +622,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -814,24 +644,15 @@
           "lineCode": "M-161",
           "lineName": "Barbate-Facinas-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-08-07T10:10:00.000Z",
+          "scheduledTime": "2026-08-09T10:10:00.000Z",
           "direction": 1,
           "stopType": 0
-        },
-        {
-          "lineId": "7",
-          "lineCode": "M-150",
-          "lineName": "Algeciras-Tarifa",
-          "destination": "Algeciras",
-          "scheduledTime": "2026-08-07T10:45:00.000Z",
-          "direction": 2,
-          "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -850,25 +671,25 @@
           "lineId": "1",
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
-          "destination": "Los Barrios",
-          "scheduledTime": "2026-08-07T10:30:00.000Z",
-          "direction": 2,
+          "destination": "Algeciras",
+          "scheduledTime": "2026-08-09T10:30:00.000Z",
+          "direction": 1,
           "stopType": 0
         },
         {
           "lineId": "1",
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
-          "destination": "Algeciras",
-          "scheduledTime": "2026-08-07T10:30:00.000Z",
-          "direction": 1,
+          "destination": "Los Barrios",
+          "scheduledTime": "2026-08-09T10:30:00.000Z",
+          "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -888,15 +709,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-08-07T10:03:00.000Z",
+          "scheduledTime": "2026-08-09T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -916,8 +737,17 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-08-07T10:45:00.000Z",
+          "scheduledTime": "2026-08-09T10:45:00.000Z",
           "direction": 1,
+          "stopType": 1
+        },
+        {
+          "lineId": "11",
+          "lineCode": "M-230",
+          "lineName": "La Línea-San Roque",
+          "destination": "La Línea de la Concepción",
+          "scheduledTime": "2026-08-09T10:45:00.000Z",
+          "direction": 2,
           "stopType": 1
         },
         {
@@ -925,15 +755,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-08-07T11:00:00.000Z",
+          "scheduledTime": "2026-08-09T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -952,34 +782,16 @@
           "lineId": "40",
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
-          "destination": "ADRA",
-          "scheduledTime": "2026-08-07T10:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "40",
-          "lineCode": "M-380",
-          "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-08-07T10:48:00.000Z",
+          "scheduledTime": "2026-08-09T10:33:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "48",
-          "lineCode": "M-384",
-          "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
-          "destination": "ADRA",
-          "scheduledTime": "2026-08-07T10:51:00.000Z",
-          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -995,9 +807,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -1013,9 +825,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -1031,9 +843,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -1049,9 +861,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T11:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T11:00:00.000Z"
       }
     },
     {
@@ -1067,9 +879,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T12:30:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T12:30:00.000Z"
       }
     },
     {
@@ -1085,20 +897,20 @@
       "nucleus": "Torredelcampo",
       "services": [
         {
+          "lineId": "289",
+          "lineCode": "M20-13",
+          "lineName": "Jaén - Jamilena - Martos, 2024",
+          "destination": "Jaén",
+          "scheduledTime": "2026-08-09T10:33:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
           "lineId": "278",
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-08-07T10:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-08-07T10:38:00.000Z",
+          "scheduledTime": "2026-08-09T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1106,26 +918,17 @@
           "lineId": "283",
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
-          "destination": "Torredonjimeno",
-          "scheduledTime": "2026-08-07T10:50:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-07T11:13:00.000Z",
+          "scheduledTime": "2026-08-09T10:41:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-08-07T11:20:00.000Z",
+          "lineId": "283",
+          "lineCode": "M20-06",
+          "lineName": "Jaén - Córdoba (Ruta), 2024",
+          "destination": "Torredonjimeno",
+          "scheduledTime": "2026-08-09T11:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1133,34 +936,25 @@
           "lineId": "281",
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-08-09T11:55:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "278",
+          "lineCode": "M20-01",
+          "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-07T11:43:00.000Z",
+          "scheduledTime": "2026-08-09T12:28:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "288",
-          "lineCode": "M20-12",
-          "lineName": "Jaén - Escañuela, 2024",
-          "destination": "Escañuela",
-          "scheduledTime": "2026-08-07T11:55:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "285",
-          "lineCode": "M20-08",
-          "lineName": "Jaén - Lopera, 2024",
-          "destination": "Torredonjimeno",
-          "scheduledTime": "2026-08-07T12:20:00.000Z",
-          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T12:30:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T12:30:00.000Z"
       }
     },
     {
@@ -1176,29 +970,11 @@
       "nucleus": "Torredonjimeno",
       "services": [
         {
-          "lineId": "287",
-          "lineCode": "M20-11",
-          "lineName": "Fuensanta de Martos - Jaén, 2024",
+          "lineId": "289",
+          "lineCode": "M20-13",
+          "lineName": "Jaén - Jamilena - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-07T10:25:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Martos",
-          "scheduledTime": "2026-08-07T10:33:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "278",
-          "lineCode": "M20-01",
-          "lineName": "Jaén - Martos, 2024",
-          "destination": "Jaén",
-          "scheduledTime": "2026-08-07T11:00:00.000Z",
+          "scheduledTime": "2026-08-09T10:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1206,17 +982,8 @@
           "lineId": "283",
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
-          "destination": "Torredonjimeno",
-          "scheduledTime": "2026-08-07T11:03:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "281",
-          "lineCode": "M20-04",
-          "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-07T11:30:00.000Z",
+          "scheduledTime": "2026-08-09T10:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1225,16 +992,25 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-08-07T11:33:00.000Z",
+          "scheduledTime": "2026-08-09T10:48:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "288",
-          "lineCode": "M20-12",
-          "lineName": "Jaén - Escañuela, 2024",
-          "destination": "Escañuela",
-          "scheduledTime": "2026-08-07T12:08:00.000Z",
+          "lineId": "283",
+          "lineCode": "M20-06",
+          "lineName": "Jaén - Córdoba (Ruta), 2024",
+          "destination": "Torredonjimeno",
+          "scheduledTime": "2026-08-09T11:33:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "281",
+          "lineCode": "M20-04",
+          "lineName": "Jaén - Alcaudete, 2024",
+          "destination": "Martos",
+          "scheduledTime": "2026-08-09T12:08:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1243,15 +1019,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-07T12:25:00.000Z",
+          "scheduledTime": "2026-08-09T12:15:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T12:30:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T12:30:00.000Z"
       }
     },
     {
@@ -1270,97 +1046,16 @@
           "lineId": "203",
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-08-07T10:00:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-08-07T10:05:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "73",
-          "lineCode": "M16-3",
-          "lineName": "Bailén - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-08-07T10:15:00.000Z",
+          "scheduledTime": "2026-08-09T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
-        },
-        {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-08-07T10:40:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-08-07T11:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "71",
-          "lineCode": "M16-1",
-          "lineName": "Santa Elena - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-08-07T11:25:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-08-07T11:30:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "72",
-          "lineCode": "M16-2",
-          "lineName": "La Carolina - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-08-07T11:45:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "203",
-          "lineCode": "M04-8",
-          "lineName": "Linares - Jaén",
-          "destination": "Mengíbar",
-          "scheduledTime": "2026-08-07T11:55:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "276",
-          "lineCode": "M15-7",
-          "lineName": "Jaén - Andújar - Marmolejo",
-          "destination": "Andújar",
-          "scheduledTime": "2026-08-07T12:25:00.000Z",
-          "direction": 1,
-          "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T12:30:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T12:30:00.000Z"
       }
     },
     {
@@ -1374,57 +1069,11 @@
       },
       "municipality": "Mancha Real",
       "nucleus": "Mancha Real",
-      "services": [
-        {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-08-07T10:30:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-08-07T10:55:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "35",
-          "lineCode": "M3-103",
-          "lineName": "Úbeda - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-08-07T11:00:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
-          "destination": "Jaén",
-          "scheduledTime": "2026-08-07T11:30:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "17",
-          "lineCode": "M1-9",
-          "lineName": "Mancha Real - Jaén",
-          "destination": "Mancha Real",
-          "scheduledTime": "2026-08-07T11:55:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        }
-      ],
+      "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T12:30:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T12:30:00.000Z"
       }
     },
     {
@@ -1440,9 +1089,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-08T02:39:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-10T02:39:00.000Z"
       }
     },
     {
@@ -1458,9 +1107,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-08T02:39:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-10T02:39:00.000Z"
       }
     },
     {
@@ -1476,9 +1125,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-08T02:39:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-10T02:39:00.000Z"
       }
     },
     {
@@ -1494,9 +1143,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-08T02:39:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-10T02:39:00.000Z"
       }
     },
     {
@@ -1512,9 +1161,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-08T02:39:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-10T02:39:00.000Z"
       }
     },
     {
@@ -1534,26 +1183,17 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-08-07T10:00:00.000Z",
+          "scheduledTime": "2026-08-09T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "13",
-          "lineCode": "M-303",
-          "lineName": "Huelva-Corrales-Ayamonte",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-07T10:04:00.000Z",
+          "scheduledTime": "2026-08-09T10:03:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "69",
-          "lineCode": "M-905",
-          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-07T10:21:00.000Z",
-          "direction": 1,
           "stopType": 0
         },
         {
@@ -1561,7 +1201,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-08-07T10:42:00.000Z",
+          "scheduledTime": "2026-08-09T10:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1570,43 +1210,16 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-08-07T11:00:00.000Z",
+          "scheduledTime": "2026-08-09T11:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "13",
-          "lineCode": "M-303",
-          "lineName": "Huelva-Corrales-Ayamonte",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-08-07T11:04:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-07T11:11:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "66",
-          "lineCode": "M-902",
-          "lineName": "Ayamonte-Huelva-Sevilla",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-08-07T11:21:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-07T11:41:00.000Z",
+          "scheduledTime": "2026-08-09T11:22:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1615,7 +1228,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-08-07T11:42:00.000Z",
+          "scheduledTime": "2026-08-09T11:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1624,7 +1237,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-07T11:44:00.000Z",
+          "scheduledTime": "2026-08-09T11:44:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1633,16 +1246,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-08-07T12:00:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "8",
-          "lineCode": "M-316",
-          "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
-          "destination": "VILLABLANCA",
-          "scheduledTime": "2026-08-07T12:36:00.000Z",
+          "scheduledTime": "2026-08-09T12:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1651,7 +1255,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-08-07T12:42:00.000Z",
+          "scheduledTime": "2026-08-09T12:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1660,25 +1264,16 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-08-07T13:00:00.000Z",
+          "scheduledTime": "2026-08-09T13:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-08-07T13:15:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "69",
-          "lineCode": "M-905",
-          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-07T13:21:00.000Z",
+          "lineId": "5",
+          "lineCode": "M-310",
+          "lineName": "Huelva-Isla Cristina-Ayamonte",
+          "destination": "AYAMONTE",
+          "scheduledTime": "2026-08-09T13:38:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1687,24 +1282,15 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-08-07T13:42:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "69",
-          "lineCode": "M-905",
-          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-08-07T13:44:00.000Z",
+          "scheduledTime": "2026-08-09T13:42:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T14:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T14:00:00.000Z"
       }
     },
     {
@@ -1723,70 +1309,34 @@
           "lineId": "69",
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-07T10:49:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "69",
-          "lineCode": "M-905",
-          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-07T11:20:00.000Z",
+          "scheduledTime": "2026-08-09T11:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
         {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-07T11:50:00.000Z",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
+          "destination": "AYAMONTE",
+          "scheduledTime": "2026-08-09T12:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
         {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-07T12:20:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "36",
-          "lineCode": "M-309",
-          "lineName": "Huelva-La Antilla-Isla Cristina",
+          "lineId": "76",
+          "lineCode": "M-912",
+          "lineName": "Sevillla-Huelva-Isla Cristina-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-07T12:30:00.000Z",
+          "scheduledTime": "2026-08-09T13:20:00.000Z",
           "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "69",
-          "lineCode": "M-905",
-          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-08-07T13:20:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "69",
-          "lineCode": "M-905",
-          "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
-          "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-07T13:49:00.000Z",
-          "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T14:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T14:00:00.000Z"
       }
     },
     {
@@ -1806,7 +1356,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-07T10:03:00.000Z",
+          "scheduledTime": "2026-08-09T10:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1815,7 +1365,7 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-07T10:14:00.000Z",
+          "scheduledTime": "2026-08-09T10:14:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1824,7 +1374,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-08-07T10:48:00.000Z",
+          "scheduledTime": "2026-08-09T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1833,8 +1383,53 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-07T11:03:00.000Z",
+          "scheduledTime": "2026-08-09T11:03:00.000Z",
           "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "ALMONTE",
+          "scheduledTime": "2026-08-09T11:48:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-08-09T12:03:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "ALMONTE",
+          "scheduledTime": "2026-08-09T12:48:00.000Z",
+          "direction": 2,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "TORRE DE LA HIGUERA",
+          "scheduledTime": "2026-08-09T13:03:00.000Z",
+          "direction": 1,
+          "stopType": 0
+        },
+        {
+          "lineId": "59",
+          "lineCode": "M-416",
+          "lineName": "Almonte-Torre Higuera",
+          "destination": "ALMONTE",
+          "scheduledTime": "2026-08-09T13:48:00.000Z",
+          "direction": 2,
           "stopType": 0
         },
         {
@@ -1842,88 +1437,7 @@
           "lineCode": "M-417",
           "lineName": "Paterna-Torre Higuera",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-08-07T11:18:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "ALMONTE",
-          "scheduledTime": "2026-08-07T11:48:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-07T12:03:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "48",
-          "lineCode": "M-405",
-          "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
-          "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-08-07T12:36:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "70",
-          "lineCode": "M-906",
-          "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
-          "destination": "ROCIANA DEL CONDADO",
-          "scheduledTime": "2026-08-07T12:43:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "ALMONTE",
-          "scheduledTime": "2026-08-07T12:48:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-07T13:03:00.000Z",
-          "direction": 1,
-          "stopType": 0
-        },
-        {
-          "lineId": "60",
-          "lineCode": "M-417",
-          "lineName": "Paterna-Torre Higuera",
-          "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-08-07T13:48:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "59",
-          "lineCode": "M-416",
-          "lineName": "Almonte-Torre Higuera",
-          "destination": "ALMONTE",
-          "scheduledTime": "2026-08-07T13:48:00.000Z",
-          "direction": 2,
-          "stopType": 0
-        },
-        {
-          "lineId": "48",
-          "lineCode": "M-405",
-          "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
-          "destination": "HUELVA",
-          "scheduledTime": "2026-08-07T13:52:00.000Z",
+          "scheduledTime": "2026-08-09T13:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1932,15 +1446,15 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "HINOJOS",
-          "scheduledTime": "2026-08-07T13:58:00.000Z",
+          "scheduledTime": "2026-08-09T13:58:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T14:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T14:00:00.000Z"
       }
     },
     {
@@ -1956,9 +1470,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T14:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T14:00:00.000Z"
       }
     },
     {
@@ -1974,9 +1488,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-07T06:09:42.150Z",
-        "startTime": "2026-08-07T10:00:00.000Z",
-        "endTime": "2026-08-07T14:00:00.000Z"
+        "requestedAt": "2026-08-09T05:47:31.648Z",
+        "startTime": "2026-08-09T10:00:00.000Z",
+        "endTime": "2026-08-09T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:32.367Z",
+    "generatedAt": "2026-08-09T05:47:24.643Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:32.367Z",
+    "generatedAt": "2026-08-09T05:47:24.643Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:32.367Z",
+    "generatedAt": "2026-08-09T05:47:24.643Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:32.367Z",
+    "generatedAt": "2026-08-09T05:47:24.643Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:32.367Z",
+    "generatedAt": "2026-08-09T05:47:24.643Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:32.367Z",
+    "generatedAt": "2026-08-09T05:47:24.643Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:32.367Z",
+    "generatedAt": "2026-08-09T05:47:24.643Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:32.367Z",
+    "generatedAt": "2026-08-09T05:47:24.643Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:32.367Z",
+    "generatedAt": "2026-08-09T05:47:24.643Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-07T06:09:32.367Z",
+    "generatedAt": "2026-08-09T05:47:24.643Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-08-09 05:48 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nine Málaga-area bus routes, including seasonal Feria de Málaga services.
  * Added the Jaén–Martos direct bus line.
* **Updates**
  * Refreshed transport service results across Andalucía, including route, destination, direction, and schedule changes.
  * Updated catalog and stop-directory data timestamps.
  * Updated service availability windows for Granada, Málaga, Jaén, Córdoba, and Huelva.
  * Refreshed news indicators for six Granada transit lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->