### PR TITLE
fix(actions): harden required QA runtime

### DIFF
--- a/.agents/specs/2026-08-08-actions-runtime-hardening.md
+++ b/.agents/specs/2026-08-08-actions-runtime-hardening.md
@@ -1,0 +1,36 @@
+# Actions runtime hardening
+
+## Request
+
+Correct the shared required-QA Dependabot merge automation using the runtime failures observed across the rollout without weakening the repository security model.
+
+## Evidence
+
+- The shared GraphQL auto-merge path fails when GitHub already reports an approved pull request as `clean`.
+- Refreshing a behind Dependabot branch that changes `.github/workflows/*` can require the sensitive Workflows permission.
+- `daily-snapshot.yml` already establishes `PAT_FINE` in the protected `admin` environment as the owner identity for event-emitting repository writes.
+- Immediate merges made with `GITHUB_TOKEN` suppress most downstream workflow runs.
+
+## Decision
+
+- Preserve and revalidate exact-head, non-bot, write-maintainer QA approval.
+- Reuse the existing protected `admin` Actions `PAT_FINE`, validate it as the repository owner, and use it for live branch/merge transitions.
+- Squash-merge the exact approved head when GitHub reports `clean`; otherwise enable repository auto-merge when available.
+- Never grant Workflows permission. Workflow-changing behind PRs require a trusted manual update and then a fresh approval.
+- Keep dry-run non-mutating.
+
+## Acceptance
+
+Clean approved majors do not fail; workflow-file refresh does not escalate permission; stale, bot, changed, conflicted or change-requested heads cannot merge; downstream workflows are not intentionally suppressed.
+
+## Checks
+
+Parse workflow YAML, syntax-check shell and `github-script` programs, verify immutable Action SHAs, and use pull-request CI as authority.
+
+## Rollback
+
+Revert the corrective pull request. No merge, deployment or publication is performed by this branch.
+
+## Delivery status
+
+Implemented on `agent/fix-actions-runtime-20260808`; pending pull-request CI and explicit owner merge approval.

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -80,8 +80,10 @@ jobs:
             const defaultBranch = context.payload.repository.default_branch;
             const repository = await github.rest.repos.get({ owner, repo });
             const autoMergeAllowed = repository.data.allow_auto_merge === true;
+            const hasRequiredQaLabel = (pullRequest) => pullRequest.labels.some((label) => label.name === 'requires-manual-qa');
+            const isTrustedCandidate = (pullRequest) => pullRequest.user?.login === 'dependabot[bot]' && pullRequest.base.ref === defaultBranch && pullRequest.head.repo?.full_name === `${owner}/${repo}` && hasRequiredQaLabel(pullRequest);
             const pullRequests = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 });
-            const candidates = pullRequests.filter((pullRequest) => pullRequest.user?.login === 'dependabot[bot]' && pullRequest.base.ref === defaultBranch && pullRequest.head.repo?.full_name === `${owner}/${repo}` && pullRequest.labels.some((label) => label.name === 'requires-manual-qa'));
+            const candidates = pullRequests.filter(isTrustedCandidate);
             const permissionCache = new Map();
             const decisiveReviewStates = new Set(['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED']);
             const hasWritePermission = async (login) => {
@@ -130,6 +132,7 @@ jobs:
               try {
                 const current = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
                 const currentHeadSha = current.data.head.sha;
+                if (!isTrustedCandidate(current.data)) { results.push({ number: candidate.number, action: 'skipped', reason: 'candidate trust contract changed' }); continue; }
                 if (current.data.mergeable_state === 'behind') {
                   if (await hasWorkflowChanges(candidate.number)) { results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'branch is behind and changes workflow files; automation will not request workflows permission' }); continue; }
                   if (dryRun) { results.push({ number: candidate.number, action: 'would-update-branch', reason: 'fresh approval required after the update' }); continue; }
@@ -145,6 +148,7 @@ jobs:
                 const approval = await readApprovalState(candidate.number, currentHeadSha);
                 if (!approval.approved || approval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: approval.changesRequested ? 'current maintainer review requests changes' : 'no maintainer approval for the current head commit' }); continue; }
                 const verified = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+                if (!isTrustedCandidate(verified.data)) { results.push({ number: candidate.number, action: 'skipped', reason: 'candidate trust contract changed during validation' }); continue; }
                 if (verified.data.head.sha !== currentHeadSha) { results.push({ number: candidate.number, action: 'skipped', reason: 'head commit changed during validation' }); continue; }
                 const verifiedApproval = await readApprovalState(candidate.number, currentHeadSha);
                 if (!verifiedApproval.approved || verifiedApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'maintainer approval changed during validation' }); continue; }
@@ -159,7 +163,7 @@ jobs:
                     if (!becameClean) throw error;
                     const clean = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
                     const cleanApproval = await readApprovalState(candidate.number, currentHeadSha);
-                    if (clean.data.head.sha !== currentHeadSha || clean.data.mergeable_state !== 'clean' || !cleanApproval.approved || cleanApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'pull request changed while enabling auto-merge' }); continue; }
+                    if (!isTrustedCandidate(clean.data) || clean.data.head.sha !== currentHeadSha || clean.data.mergeable_state !== 'clean' || !cleanApproval.approved || cleanApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'pull request changed while enabling auto-merge' }); continue; }
                     await mergeCleanPullRequest(candidate.number, currentHeadSha);
                     results.push({ number: candidate.number, action: 'merged-after-clean-race' });
                     continue;

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "$GH_TOKEN" ]]; then
-            echo "::error title=Missing Actions secret::Configure PAT_FINE in the protected admin environment with Pull requests read/write permission."
+            echo "::error title=Missing Actions secret::Configure PAT_FINE in the protected admin environment with Contents and Pull requests write permission."
             exit 1
           fi
           authenticated_login=$(gh api user --jq .login)
@@ -83,6 +83,7 @@ jobs:
             const pullRequests = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 });
             const candidates = pullRequests.filter((pullRequest) => pullRequest.user?.login === 'dependabot[bot]' && pullRequest.base.ref === defaultBranch && pullRequest.head.repo?.full_name === `${owner}/${repo}` && pullRequest.labels.some((label) => label.name === 'requires-manual-qa'));
             const permissionCache = new Map();
+            const decisiveReviewStates = new Set(['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED']);
             const hasWritePermission = async (login) => {
               if (permissionCache.has(login)) return permissionCache.get(login);
               try {
@@ -101,7 +102,7 @@ jobs:
               for (const review of reviews) {
                 const login = review.user?.login;
                 const submittedAt = Date.parse(review.submitted_at ?? '');
-                if (!login || !Number.isFinite(submittedAt) || review.commit_id !== headSha) continue;
+                if (!login || !Number.isFinite(submittedAt) || review.commit_id !== headSha || !decisiveReviewStates.has(review.state)) continue;
                 const previous = latestReviewByUser.get(login);
                 if (!previous || submittedAt > previous.submittedAt) latestReviewByUser.set(login, { state: review.state, submittedAt });
               }
@@ -120,50 +121,55 @@ jobs:
             };
             const mergeCleanPullRequest = async (pullNumber, headSha) => {
               const merge = await github.rest.pulls.merge({ owner, repo, pull_number: pullNumber, merge_method: 'squash', sha: headSha });
-              if (!merge.data.merged) throw new Error(`GitHub did not merge #${pullNumber}: ${merge.data.message}`);
+              if (!merge.data.merged) throw new Error(`GitHub did not merge #${pullNumber}`);
             };
+            const failureReason = (error) => Number.isInteger(error?.status) ? `GitHub request failed with HTTP ${error.status}` : 'GitHub request failed unexpectedly';
             const results = [];
+            let failures = 0;
             for (const candidate of candidates) {
-              const current = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
-              const currentHeadSha = current.data.head.sha;
-              if (current.data.mergeable_state === 'behind') {
-                if (await hasWorkflowChanges(candidate.number)) {
-                  results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'branch is behind and changes workflow files; automation will not request workflows permission' });
+              try {
+                const current = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+                const currentHeadSha = current.data.head.sha;
+                if (current.data.mergeable_state === 'behind') {
+                  if (await hasWorkflowChanges(candidate.number)) { results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'branch is behind and changes workflow files; automation will not request workflows permission' }); continue; }
+                  if (dryRun) { results.push({ number: candidate.number, action: 'would-update-branch', reason: 'fresh approval required after the update' }); continue; }
+                  try { await github.rest.pulls.updateBranch({ owner, repo, pull_number: candidate.number, expected_head_sha: currentHeadSha }); } catch (error) {
+                    const workflowPermissionFailure = error.status === 403 && String(error.message).includes('workflows permission');
+                    if (!workflowPermissionFailure) throw error;
+                    results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'GitHub refused the branch update because workflow-file changes require workflows permission' });
+                    continue;
+                  }
+                  results.push({ number: candidate.number, action: 'branch-update-requested', reason: 'fresh approval required for the new head commit' });
                   continue;
                 }
-                if (dryRun) { results.push({ number: candidate.number, action: 'would-update-branch', reason: 'fresh approval required after the update' }); continue; }
-                try { await github.rest.pulls.updateBranch({ owner, repo, pull_number: candidate.number, expected_head_sha: currentHeadSha }); } catch (error) {
-                  const workflowPermissionFailure = error.status === 403 && String(error.message).includes('workflows permission');
-                  if (!workflowPermissionFailure) throw error;
-                  results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'GitHub refused the branch update because workflow-file changes require workflows permission' });
-                  continue;
+                const approval = await readApprovalState(candidate.number, currentHeadSha);
+                if (!approval.approved || approval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: approval.changesRequested ? 'current maintainer review requests changes' : 'no maintainer approval for the current head commit' }); continue; }
+                const verified = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+                if (verified.data.head.sha !== currentHeadSha) { results.push({ number: candidate.number, action: 'skipped', reason: 'head commit changed during validation' }); continue; }
+                const verifiedApproval = await readApprovalState(candidate.number, currentHeadSha);
+                if (!verifiedApproval.approved || verifiedApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'maintainer approval changed during validation' }); continue; }
+                if (verified.data.mergeable_state === 'behind') { results.push({ number: candidate.number, action: 'skipped', reason: 'branch became outdated during validation' }); continue; }
+                if (verified.data.mergeable_state === 'dirty' || verified.data.mergeable_state === 'unknown') { results.push({ number: candidate.number, action: 'skipped', reason: `merge state is ${verified.data.mergeable_state}` }); continue; }
+                if (dryRun) { results.push({ number: candidate.number, action: verified.data.mergeable_state === 'clean' ? 'would-merge' : autoMergeAllowed ? 'would-enable-auto-merge' : 'would-wait-for-requirements' }); continue; }
+                if (verified.data.mergeable_state === 'clean') { await mergeCleanPullRequest(candidate.number, currentHeadSha); results.push({ number: candidate.number, action: 'merged' }); continue; }
+                if (!autoMergeAllowed) { results.push({ number: candidate.number, action: 'waiting-for-requirements', reason: 'repository auto-merge is disabled; a later run will merge once GitHub reports clean' }); continue; }
+                if (!verified.data.auto_merge) {
+                  try { await github.graphql(`mutation EnableAutoMerge($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) { enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId mergeMethod: SQUASH expectedHeadOid: $expectedHeadOid }) { pullRequest { number } } }`, { pullRequestId: verified.data.node_id, expectedHeadOid: currentHeadSha }); } catch (error) {
+                    const becameClean = error.errors?.some((entry) => String(entry.message).includes('clean status'));
+                    if (!becameClean) throw error;
+                    const clean = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+                    const cleanApproval = await readApprovalState(candidate.number, currentHeadSha);
+                    if (clean.data.head.sha !== currentHeadSha || clean.data.mergeable_state !== 'clean' || !cleanApproval.approved || cleanApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'pull request changed while enabling auto-merge' }); continue; }
+                    await mergeCleanPullRequest(candidate.number, currentHeadSha);
+                    results.push({ number: candidate.number, action: 'merged-after-clean-race' });
+                    continue;
+                  }
                 }
-                results.push({ number: candidate.number, action: 'branch-update-requested', reason: 'fresh approval required for the new head commit' });
-                continue;
+                results.push({ number: candidate.number, action: 'auto-merge-enabled' });
+              } catch (error) {
+                failures += 1;
+                results.push({ number: candidate.number, action: 'failed', reason: failureReason(error) });
               }
-              const approval = await readApprovalState(candidate.number, currentHeadSha);
-              if (!approval.approved || approval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: approval.changesRequested ? 'current maintainer review requests changes' : 'no maintainer approval for the current head commit' }); continue; }
-              const verified = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
-              if (verified.data.head.sha !== currentHeadSha) { results.push({ number: candidate.number, action: 'skipped', reason: 'head commit changed during validation' }); continue; }
-              const verifiedApproval = await readApprovalState(candidate.number, currentHeadSha);
-              if (!verifiedApproval.approved || verifiedApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'maintainer approval changed during validation' }); continue; }
-              if (verified.data.mergeable_state === 'behind') { results.push({ number: candidate.number, action: 'skipped', reason: 'branch became outdated during validation' }); continue; }
-              if (verified.data.mergeable_state === 'dirty' || verified.data.mergeable_state === 'unknown') { results.push({ number: candidate.number, action: 'skipped', reason: `merge state is ${verified.data.mergeable_state}` }); continue; }
-              if (dryRun) { results.push({ number: candidate.number, action: verified.data.mergeable_state === 'clean' ? 'would-merge' : autoMergeAllowed ? 'would-enable-auto-merge' : 'would-wait-for-requirements' }); continue; }
-              if (verified.data.mergeable_state === 'clean') { await mergeCleanPullRequest(candidate.number, currentHeadSha); results.push({ number: candidate.number, action: 'merged' }); continue; }
-              if (!autoMergeAllowed) { results.push({ number: candidate.number, action: 'waiting-for-requirements', reason: 'repository auto-merge is disabled; a later run will merge once GitHub reports clean' }); continue; }
-              if (!verified.data.auto_merge) {
-                try { await github.graphql(`mutation EnableAutoMerge($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) { enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId mergeMethod: SQUASH expectedHeadOid: $expectedHeadOid }) { pullRequest { number } } }`, { pullRequestId: verified.data.node_id, expectedHeadOid: currentHeadSha }); } catch (error) {
-                  const becameClean = error.errors?.some((entry) => String(entry.message).includes('clean status'));
-                  if (!becameClean) throw error;
-                  const clean = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
-                  const cleanApproval = await readApprovalState(candidate.number, currentHeadSha);
-                  if (clean.data.head.sha !== currentHeadSha || clean.data.mergeable_state !== 'clean' || !cleanApproval.approved || cleanApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'pull request changed while enabling auto-merge' }); continue; }
-                  await mergeCleanPullRequest(candidate.number, currentHeadSha);
-                  results.push({ number: candidate.number, action: 'merged-after-clean-race' });
-                  continue;
-                }
-              }
-              results.push({ number: candidate.number, action: 'auto-merge-enabled' });
             }
             await core.summary.addHeading('Required QA auto-merge').addRaw(results.length === 0 ? 'No eligible Dependabot pull requests found.' : results.map((result) => `- #${result.number}: ${result.action}${result.reason ? ` — ${result.reason}` : ''}`).join('\n')).write();
+            if (failures > 0) core.setFailed(`${failures} Dependabot pull request(s) failed processing.`);

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: Report eligible pull requests without enabling auto-merge
+        description: Report eligible pull requests without changing branches or merge state
         required: true
         default: true
         type: boolean
@@ -23,12 +23,13 @@ jobs:
     if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: admin
     permissions:
-      contents: write
+      contents: read
       issues: write
-      pull-requests: write
+      pull-requests: read
     steps:
-      - name: Synchronize manual QA label
+      - name: Synchronize automation labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           DRY_RUN: ${{ inputs.dry_run || false }}
@@ -37,248 +38,132 @@ jobs:
           script: |
             const dryRun = process.env.DRY_RUN === 'true';
             const { owner, repo } = context.repo;
-            const label = {
-              name: 'requires-manual-qa',
-              color: 'E99695',
-              description: 'Needs manual quality assurance testing before merging',
-            };
-
-            if (dryRun) {
-              core.info(`Would synchronize label ${label.name}.`);
-              return;
-            }
-
-            const updateLabel = () =>
-              github.rest.issues.updateLabel({
-                owner,
-                repo,
-                name: label.name,
-                new_name: label.name,
-                color: label.color,
-                description: label.description,
-              });
-
-            try {
-              await updateLabel();
-            } catch (error) {
-              if (error.status !== 404) {
-                throw error;
-              }
-
-              try {
-                await github.rest.issues.createLabel({ owner, repo, ...label });
-              } catch (createError) {
-                const duplicate =
-                  createError.status === 422 &&
-                  createError.response?.data?.errors?.some(
-                    (entry) => entry.code === 'already_exists',
-                  );
-                if (!duplicate) {
-                  throw createError;
+            const labels = [{ name: 'requires-manual-qa', color: 'E99695', description: 'Needs manual quality assurance testing before merging' }];
+            const updateLabel = (label) => github.rest.issues.updateLabel({ owner, repo, name: label.name, new_name: label.name, color: label.color, description: label.description });
+            for (const label of labels) {
+              if (dryRun) { core.info(`Would synchronize label ${label.name}.`); continue; }
+              try { await updateLabel(label); } catch (error) {
+                if (error.status !== 404) throw error;
+                try { await github.rest.issues.createLabel({ owner, repo, ...label }); } catch (createError) {
+                  const duplicate = createError.status === 422 && createError.response?.data?.errors?.some((entry) => entry.code === 'already_exists');
+                  if (!duplicate) throw createError;
+                  await updateLabel(label);
                 }
-                await updateLabel();
               }
             }
 
-      - name: Validate current approvals and enable auto-merge
+      - name: Validate trusted merge identity
+        if: inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error title=Missing Actions secret::Configure PAT_FINE in the protected admin environment with Pull requests read/write permission."
+            exit 1
+          fi
+          authenticated_login=$(gh api user --jq .login)
+          if [[ "$authenticated_login" != "$GITHUB_REPOSITORY_OWNER" ]]; then
+            echo "::error title=Invalid merge actor::PAT_FINE authenticates as $authenticated_login instead of $GITHUB_REPOSITORY_OWNER."
+            exit 1
+          fi
+
+      - name: Validate current approvals and queue or merge
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           DRY_RUN: ${{ inputs.dry_run || false }}
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ inputs.dry_run == true && github.token || secrets.PAT_FINE }}
           script: |
             const dryRun = process.env.DRY_RUN === 'true';
             const { owner, repo } = context.repo;
             const defaultBranch = context.payload.repository.default_branch;
-            const pullRequests = await github.paginate(
-              github.rest.pulls.list,
-              { owner, repo, state: 'open', per_page: 100 },
-            );
-
-            const candidates = pullRequests.filter(
-              (pullRequest) =>
-                pullRequest.user?.login === 'dependabot[bot]' &&
-                pullRequest.base.ref === defaultBranch &&
-                pullRequest.head.repo?.full_name === `${owner}/${repo}` &&
-                pullRequest.labels.some(
-                  (label) => label.name === 'requires-manual-qa',
-                ),
-            );
-
+            const repository = await github.rest.repos.get({ owner, repo });
+            const autoMergeAllowed = repository.data.allow_auto_merge === true;
+            const pullRequests = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 });
+            const candidates = pullRequests.filter((pullRequest) => pullRequest.user?.login === 'dependabot[bot]' && pullRequest.base.ref === defaultBranch && pullRequest.head.repo?.full_name === `${owner}/${repo}` && pullRequest.labels.some((label) => label.name === 'requires-manual-qa'));
             const permissionCache = new Map();
             const hasWritePermission = async (login) => {
-              if (permissionCache.has(login)) {
-                return permissionCache.get(login);
-              }
-
+              if (permissionCache.has(login)) return permissionCache.get(login);
               try {
-                const response =
-                  await github.rest.repos.getCollaboratorPermissionLevel({
-                    owner,
-                    repo,
-                    username: login,
-                  });
-                const allowed = ['admin', 'maintain', 'write'].includes(
-                  response.data.permission,
-                );
+                const response = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username: login });
+                const allowed = ['admin', 'maintain', 'write'].includes(response.data.permission);
                 permissionCache.set(login, allowed);
                 return allowed;
               } catch (error) {
-                if (error.status === 404) {
-                  permissionCache.set(login, false);
-                  return false;
-                }
+                if (error.status === 404) { permissionCache.set(login, false); return false; }
                 throw error;
               }
             };
-
-            const results = [];
-            for (const candidate of candidates) {
-              const current = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: candidate.number,
-              });
-              const currentHeadSha = current.data.head.sha;
-
-              if (current.data.mergeable_state === 'behind') {
-                if (dryRun) {
-                  results.push({
-                    number: candidate.number,
-                    action: 'would-update-branch',
-                    reason: 'fresh approval required after the update',
-                  });
-                  continue;
-                }
-
-                await github.rest.pulls.updateBranch({
-                  owner,
-                  repo,
-                  pull_number: candidate.number,
-                  expected_head_sha: currentHeadSha,
-                });
-                results.push({
-                  number: candidate.number,
-                  action: 'branch-update-requested',
-                  reason: 'fresh approval required for the new head commit',
-                });
-                continue;
-              }
-
-              const reviews = await github.paginate(
-                github.rest.pulls.listReviews,
-                { owner, repo, pull_number: candidate.number, per_page: 100 },
-              );
+            const readApprovalState = async (pullNumber, headSha) => {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number: pullNumber, per_page: 100 });
               const latestReviewByUser = new Map();
-
               for (const review of reviews) {
                 const login = review.user?.login;
                 const submittedAt = Date.parse(review.submitted_at ?? '');
-                if (
-                  !login ||
-                  !Number.isFinite(submittedAt) ||
-                  review.commit_id !== currentHeadSha
-                ) {
-                  continue;
-                }
-
+                if (!login || !Number.isFinite(submittedAt) || review.commit_id !== headSha) continue;
                 const previous = latestReviewByUser.get(login);
-                if (!previous || submittedAt > previous.submittedAt) {
-                  latestReviewByUser.set(login, {
-                    state: review.state,
-                    submittedAt,
-                  });
-                }
+                if (!previous || submittedAt > previous.submittedAt) latestReviewByUser.set(login, { state: review.state, submittedAt });
               }
-
               let approved = false;
               let changesRequested = false;
               for (const [login, review] of latestReviewByUser) {
-                if (
-                  login.endsWith('[bot]') ||
-                  !(await hasWritePermission(login))
-                ) {
-                  continue;
-                }
+                if (login.endsWith('[bot]') || !(await hasWritePermission(login))) continue;
                 approved ||= review.state === 'APPROVED';
                 changesRequested ||= review.state === 'CHANGES_REQUESTED';
               }
-
-              if (!approved || changesRequested) {
-                results.push({
-                  number: candidate.number,
-                  action: 'skipped',
-                  reason: changesRequested
-                    ? 'current maintainer review requests changes'
-                    : 'no maintainer approval for the current head commit',
-                });
+              return { approved, changesRequested };
+            };
+            const hasWorkflowChanges = async (pullNumber) => {
+              const files = await github.paginate(github.rest.pulls.listFiles, { owner, repo, pull_number: pullNumber, per_page: 100 });
+              return files.some((file) => file.filename.startsWith('.github/workflows/'));
+            };
+            const mergeCleanPullRequest = async (pullNumber, headSha) => {
+              const merge = await github.rest.pulls.merge({ owner, repo, pull_number: pullNumber, merge_method: 'squash', sha: headSha });
+              if (!merge.data.merged) throw new Error(`GitHub did not merge #${pullNumber}: ${merge.data.message}`);
+            };
+            const results = [];
+            for (const candidate of candidates) {
+              const current = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+              const currentHeadSha = current.data.head.sha;
+              if (current.data.mergeable_state === 'behind') {
+                if (await hasWorkflowChanges(candidate.number)) {
+                  results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'branch is behind and changes workflow files; automation will not request workflows permission' });
+                  continue;
+                }
+                if (dryRun) { results.push({ number: candidate.number, action: 'would-update-branch', reason: 'fresh approval required after the update' }); continue; }
+                try { await github.rest.pulls.updateBranch({ owner, repo, pull_number: candidate.number, expected_head_sha: currentHeadSha }); } catch (error) {
+                  const workflowPermissionFailure = error.status === 403 && String(error.message).includes('workflows permission');
+                  if (!workflowPermissionFailure) throw error;
+                  results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'GitHub refused the branch update because workflow-file changes require workflows permission' });
+                  continue;
+                }
+                results.push({ number: candidate.number, action: 'branch-update-requested', reason: 'fresh approval required for the new head commit' });
                 continue;
               }
-
-              if (dryRun) {
-                results.push({
-                  number: candidate.number,
-                  action: 'would-enable-auto-merge',
-                });
-                continue;
-              }
-
-              const verified = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: candidate.number,
-              });
-              if (verified.data.head.sha !== currentHeadSha) {
-                results.push({
-                  number: candidate.number,
-                  action: 'skipped',
-                  reason: 'head commit changed during validation',
-                });
-                continue;
-              }
-
+              const approval = await readApprovalState(candidate.number, currentHeadSha);
+              if (!approval.approved || approval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: approval.changesRequested ? 'current maintainer review requests changes' : 'no maintainer approval for the current head commit' }); continue; }
+              const verified = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+              if (verified.data.head.sha !== currentHeadSha) { results.push({ number: candidate.number, action: 'skipped', reason: 'head commit changed during validation' }); continue; }
+              const verifiedApproval = await readApprovalState(candidate.number, currentHeadSha);
+              if (!verifiedApproval.approved || verifiedApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'maintainer approval changed during validation' }); continue; }
+              if (verified.data.mergeable_state === 'behind') { results.push({ number: candidate.number, action: 'skipped', reason: 'branch became outdated during validation' }); continue; }
+              if (verified.data.mergeable_state === 'dirty' || verified.data.mergeable_state === 'unknown') { results.push({ number: candidate.number, action: 'skipped', reason: `merge state is ${verified.data.mergeable_state}` }); continue; }
+              if (dryRun) { results.push({ number: candidate.number, action: verified.data.mergeable_state === 'clean' ? 'would-merge' : autoMergeAllowed ? 'would-enable-auto-merge' : 'would-wait-for-requirements' }); continue; }
+              if (verified.data.mergeable_state === 'clean') { await mergeCleanPullRequest(candidate.number, currentHeadSha); results.push({ number: candidate.number, action: 'merged' }); continue; }
+              if (!autoMergeAllowed) { results.push({ number: candidate.number, action: 'waiting-for-requirements', reason: 'repository auto-merge is disabled; a later run will merge once GitHub reports clean' }); continue; }
               if (!verified.data.auto_merge) {
-                await github.graphql(
-                  `mutation EnableAutoMerge(
-                    $pullRequestId: ID!
-                    $expectedHeadOid: GitObjectID!
-                  ) {
-                    enablePullRequestAutoMerge(
-                      input: {
-                        pullRequestId: $pullRequestId
-                        mergeMethod: SQUASH
-                        expectedHeadOid: $expectedHeadOid
-                      }
-                    ) {
-                      pullRequest {
-                        number
-                      }
-                    }
-                  }`,
-                  {
-                    pullRequestId: verified.data.node_id,
-                    expectedHeadOid: currentHeadSha,
-                  },
-                );
+                try { await github.graphql(`mutation EnableAutoMerge($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) { enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId mergeMethod: SQUASH expectedHeadOid: $expectedHeadOid }) { pullRequest { number } } }`, { pullRequestId: verified.data.node_id, expectedHeadOid: currentHeadSha }); } catch (error) {
+                  const becameClean = error.errors?.some((entry) => String(entry.message).includes('clean status'));
+                  if (!becameClean) throw error;
+                  const clean = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+                  const cleanApproval = await readApprovalState(candidate.number, currentHeadSha);
+                  if (clean.data.head.sha !== currentHeadSha || clean.data.mergeable_state !== 'clean' || !cleanApproval.approved || cleanApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'pull request changed while enabling auto-merge' }); continue; }
+                  await mergeCleanPullRequest(candidate.number, currentHeadSha);
+                  results.push({ number: candidate.number, action: 'merged-after-clean-race' });
+                  continue;
+                }
               }
-
-              results.push({
-                number: candidate.number,
-                action: 'auto-merge-enabled',
-              });
+              results.push({ number: candidate.number, action: 'auto-merge-enabled' });
             }
-
-            await core.summary
-              .addHeading('Required QA auto-merge')
-              .addRaw(
-                results.length === 0
-                  ? 'No eligible Dependabot pull requests found.'
-                  : results
-                      .map(
-                        (result) =>
-                          `- #${result.number}: ${result.action}` +
-                          `${result.reason ? ` — ${result.reason}` : ''}`,
-                      )
-                      .join('\n'),
-              )
-              .write();
+            await core.summary.addHeading('Required QA auto-merge').addRaw(results.length === 0 ? 'No eligible Dependabot pull requests found.' : results.map((result) => `- #${result.number}: ${result.action}${result.reason ? ` — ${result.reason}` : ''}`).join('\n')).write();


### PR DESCRIPTION
## What
- harden the shared required-QA automation for clean PRs, stale branches, workflow-file changes and exact-head approval races
- reuse the protected owner `PAT_FINE` for event-emitting branch/merge transitions
- refuse Workflows permission and require trusted manual refresh plus fresh approval for outdated PRs that modify workflows

## Why
The rollout exposed two concrete failures in the shared implementation: GitHub rejects `enablePullRequestAutoMerge` for an already clean PR, and branch refresh of workflow-changing PRs requires sensitive Workflows permission.

## Security
Existing exact-head non-bot maintainer approval is preserved and revalidated. No Workflows permission, `pull_request_target`, force push, or bypass flag is introduced. Dry-run remains non-mutating.

## Validation
Final diff is limited to the workflow and task spec. Pull-request CI is authoritative.

## Impact
No Dependabot PR is merged and no deployment is performed by this implementation PR.

## Rollback
Revert this pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved automated handling of required-QA pull requests, including direct merges and auto-merge when appropriate.
  - Added clearer reporting for skipped, waiting, branch-update, merge, and race-condition outcomes.
  - Added safeguards to verify approvals and current branch state before merging.

- **Bug Fixes**
  - Improved recovery from branch updates, workflow permission limitations, and changing pull-request conditions.

- **Safety**
  - Dry runs remain non-mutating, while merge actions require protected validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->