### PR TITLE
task: refresh transport snapshots

### DIFF
--- a/src/assets/data/catalog/consortium-1/lines.json
+++ b/src/assets/data/catalog/consortium-1/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/municipalities.json
+++ b/src/assets/data/catalog/consortium-1/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-1/nuclei.json
+++ b/src/assets/data/catalog/consortium-1/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/catalog/consortium-2/lines.json
+++ b/src/assets/data/catalog/consortium-2/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/municipalities.json
+++ b/src/assets/data/catalog/consortium-2/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-2/nuclei.json
+++ b/src/assets/data/catalog/consortium-2/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/catalog/consortium-3/lines.json
+++ b/src/assets/data/catalog/consortium-3/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/municipalities.json
+++ b/src/assets/data/catalog/consortium-3/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-3/nuclei.json
+++ b/src/assets/data/catalog/consortium-3/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/catalog/consortium-4/lines.json
+++ b/src/assets/data/catalog/consortium-4/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/municipalities.json
+++ b/src/assets/data/catalog/consortium-4/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-4/nuclei.json
+++ b/src/assets/data/catalog/consortium-4/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/catalog/consortium-5/lines.json
+++ b/src/assets/data/catalog/consortium-5/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/municipalities.json
+++ b/src/assets/data/catalog/consortium-5/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-5/nuclei.json
+++ b/src/assets/data/catalog/consortium-5/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/catalog/consortium-6/lines.json
+++ b/src/assets/data/catalog/consortium-6/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/municipalities.json
+++ b/src/assets/data/catalog/consortium-6/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-6/nuclei.json
+++ b/src/assets/data/catalog/consortium-6/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/catalog/consortium-7/lines.json
+++ b/src/assets/data/catalog/consortium-7/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/municipalities.json
+++ b/src/assets/data/catalog/consortium-7/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-7/nuclei.json
+++ b/src/assets/data/catalog/consortium-7/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/catalog/consortium-8/lines.json
+++ b/src/assets/data/catalog/consortium-8/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/municipalities.json
+++ b/src/assets/data/catalog/consortium-8/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-8/nuclei.json
+++ b/src/assets/data/catalog/consortium-8/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/catalog/consortium-9/lines.json
+++ b/src/assets/data/catalog/consortium-9/lines.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/municipalities.json
+++ b/src/assets/data/catalog/consortium-9/municipalities.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/consortium-9/nuclei.json
+++ b/src/assets/data/catalog/consortium-9/nuclei.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/catalog/index.json
+++ b/src/assets/data/catalog/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:39.336Z",
+    "generatedAt": "2026-08-14T06:14:59.679Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [

--- a/src/assets/data/snapshots/stop-services/latest.json
+++ b/src/assets/data/snapshots/stop-services/latest.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:43.573Z",
+    "generatedAt": "2026-08-14T06:15:04.054Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "datasetName": "stop-services"
@@ -23,15 +23,15 @@
           "lineCode": "1320",
           "lineName": "M-132 Dos Hermanas - Sevilla (Barriadas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-08-13T10:07:00.000Z",
+          "scheduledTime": "2026-08-14T10:07:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -51,7 +51,7 @@
           "lineCode": "1666",
           "lineName": "M-166 Sanlúcar la Mayor - Sevilla (por Villanueva y A-49)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-08-13T10:01:00.000Z",
+          "scheduledTime": "2026-08-14T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -60,7 +60,7 @@
           "lineCode": "1681",
           "lineName": "M-168 Benacazón - Sevilla (por Espartinas)",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-08-13T10:42:00.000Z",
+          "scheduledTime": "2026-08-14T10:42:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -69,15 +69,15 @@
           "lineCode": "1020",
           "lineName": "M-102A Circular Aljarafe (sentido A)",
           "destination": "SANLUCAR LA MAYOR",
-          "scheduledTime": "2026-08-13T10:46:00.000Z",
+          "scheduledTime": "2026-08-14T10:46:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -97,7 +97,7 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-08-13T10:02:00.000Z",
+          "scheduledTime": "2026-08-14T10:02:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -106,15 +106,15 @@
           "lineCode": "1720",
           "lineName": "M-170A Santiponce - Sevilla",
           "destination": "SEVILLA",
-          "scheduledTime": "2026-08-13T10:32:00.000Z",
+          "scheduledTime": "2026-08-14T10:32:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -130,9 +130,9 @@
       "nucleus": "SEVILLA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -152,7 +152,7 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-08-13T10:04:00.000Z",
+          "scheduledTime": "2026-08-14T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -161,7 +161,7 @@
           "lineCode": "2160",
           "lineName": "M-216 Brenes - Sevilla",
           "destination": "BRENES",
-          "scheduledTime": "2026-08-13T10:04:00.000Z",
+          "scheduledTime": "2026-08-14T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -170,15 +170,15 @@
           "lineCode": "1100",
           "lineName": "M-110 La Algaba - Sevilla",
           "destination": "LA ALGABA",
-          "scheduledTime": "2026-08-13T10:34:00.000Z",
+          "scheduledTime": "2026-08-14T10:34:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -198,15 +198,15 @@
           "lineCode": "M-560",
           "lineName": "Rota-Jerez De La Frontera",
           "destination": "Rota",
-          "scheduledTime": "2026-08-13T10:00:00.000Z",
+          "scheduledTime": "2026-08-14T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -222,9 +222,9 @@
       "nucleus": "Aeropuerto",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -244,7 +244,7 @@
           "lineCode": "M-967",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Cádiz",
-          "scheduledTime": "2026-08-13T10:05:00.000Z",
+          "scheduledTime": "2026-08-14T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -253,7 +253,7 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Jerez",
-          "scheduledTime": "2026-08-13T10:05:00.000Z",
+          "scheduledTime": "2026-08-14T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -262,7 +262,7 @@
           "lineCode": "M-967",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz  (Por Campus De Puerto Real)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-08-13T10:28:00.000Z",
+          "scheduledTime": "2026-08-14T10:28:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -271,7 +271,7 @@
           "lineCode": "M-962",
           "lineName": "Chipiona-Sanlúcar De Barrameda-San Fernando (Por Puerto Real Y Hospital)",
           "destination": "San Fernando",
-          "scheduledTime": "2026-08-13T10:35:00.000Z",
+          "scheduledTime": "2026-08-14T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -280,7 +280,7 @@
           "lineCode": "M-561",
           "lineName": "Costa Ballena-Chipiona-Sanlúcar-Jerez",
           "destination": "Jerez",
-          "scheduledTime": "2026-08-13T10:45:00.000Z",
+          "scheduledTime": "2026-08-14T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -289,15 +289,15 @@
           "lineCode": "M-964",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Jerez De La Frontera (Por Hospital)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-08-13T10:50:00.000Z",
+          "scheduledTime": "2026-08-14T10:50:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -317,7 +317,7 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-08-13T10:16:00.000Z",
+          "scheduledTime": "2026-08-14T10:16:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -326,15 +326,15 @@
           "lineCode": "M-230",
           "lineName": "Chiclana De La Frontera-Hospital De Puerto Real (Por Marquesado)",
           "destination": "Chiclana",
-          "scheduledTime": "2026-08-13T10:44:00.000Z",
+          "scheduledTime": "2026-08-14T10:44:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -354,7 +354,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-08-13T10:05:00.000Z",
+          "scheduledTime": "2026-08-14T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -363,7 +363,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-08-13T10:10:00.000Z",
+          "scheduledTime": "2026-08-14T10:10:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -372,7 +372,7 @@
           "lineCode": "M-960",
           "lineName": "Chipiona-Sanlúcar De Barrameda-Cádiz (Por Puerto Real Y Campus)",
           "destination": "Chipiona",
-          "scheduledTime": "2026-08-13T10:21:00.000Z",
+          "scheduledTime": "2026-08-14T10:21:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -381,7 +381,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Hospital Pto. Real",
-          "scheduledTime": "2026-08-13T10:35:00.000Z",
+          "scheduledTime": "2026-08-14T10:35:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -390,7 +390,7 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-08-13T10:40:00.000Z",
+          "scheduledTime": "2026-08-14T10:40:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -399,7 +399,7 @@
           "lineCode": "M-031",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real",
           "destination": "Puerto Real",
-          "scheduledTime": "2026-08-13T10:51:00.000Z",
+          "scheduledTime": "2026-08-14T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -408,15 +408,15 @@
           "lineCode": "M-030",
           "lineName": "Cádiz-Río San Pedro-Campus Universitario-Puerto Real-Hospital",
           "destination": "Cádiz",
-          "scheduledTime": "2026-08-13T11:00:00.000Z",
+          "scheduledTime": "2026-08-14T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -436,7 +436,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-08-13T10:21:00.000Z",
+          "scheduledTime": "2026-08-14T10:21:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -445,7 +445,7 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-08-13T11:06:00.000Z",
+          "scheduledTime": "2026-08-14T11:06:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -454,15 +454,15 @@
           "lineCode": "0225",
           "lineName": "Granada - P.Puente",
           "destination": "Pinos Puente",
-          "scheduledTime": "2026-08-13T11:51:00.000Z",
+          "scheduledTime": "2026-08-14T11:51:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T12:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T12:00:00.000Z"
       }
     },
     {
@@ -482,7 +482,7 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Granada",
-          "scheduledTime": "2026-08-13T10:39:00.000Z",
+          "scheduledTime": "2026-08-14T10:39:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -491,7 +491,7 @@
           "lineCode": "0318",
           "lineName": "Granada - Colomera",
           "destination": "Cerro Cauro",
-          "scheduledTime": "2026-08-13T10:41:00.000Z",
+          "scheduledTime": "2026-08-14T10:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -500,15 +500,15 @@
           "lineCode": "0117",
           "lineName": "Granada - P.Cubillas",
           "destination": "Parque del Cubillas",
-          "scheduledTime": "2026-08-13T11:30:00.000Z",
+          "scheduledTime": "2026-08-14T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T12:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T12:00:00.000Z"
       }
     },
     {
@@ -528,7 +528,7 @@
           "lineCode": "0241",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela",
           "destination": "Cijuela",
-          "scheduledTime": "2026-08-13T10:26:00.000Z",
+          "scheduledTime": "2026-08-14T10:26:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -537,7 +537,7 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-08-13T11:27:00.000Z",
+          "scheduledTime": "2026-08-14T11:27:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -546,15 +546,15 @@
           "lineCode": "0242",
           "lineName": "Granada - Santa Fe - Chauchina - Cijuela - Láchar",
           "destination": "Láchar",
-          "scheduledTime": "2026-08-13T11:57:00.000Z",
+          "scheduledTime": "2026-08-14T11:57:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T12:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T12:00:00.000Z"
       }
     },
     {
@@ -574,15 +574,15 @@
           "lineCode": "0340",
           "lineName": "Granada - Santa Fe - Cijuela - Láchar - Trasmulas - Peñuelas - C.Tajarja - El Turro",
           "destination": "Granada",
-          "scheduledTime": "2026-08-13T11:01:00.000Z",
+          "scheduledTime": "2026-08-14T11:01:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T12:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T12:00:00.000Z"
       }
     },
     {
@@ -602,7 +602,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-08-13T10:00:00.000Z",
+          "scheduledTime": "2026-08-14T10:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -611,7 +611,7 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-08-13T10:01:00.000Z",
+          "scheduledTime": "2026-08-14T10:01:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -620,7 +620,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-08-13T10:45:00.000Z",
+          "scheduledTime": "2026-08-14T10:45:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -629,7 +629,7 @@
           "lineCode": "0154",
           "lineName": "Granada-V. del Genil (Directo)",
           "destination": "Granada",
-          "scheduledTime": "2026-08-13T11:15:00.000Z",
+          "scheduledTime": "2026-08-14T11:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -638,15 +638,15 @@
           "lineCode": "0150",
           "lineName": "Granada - Cúllar V. - V. del Genil",
           "destination": "El Ventorrillo",
-          "scheduledTime": "2026-08-13T11:46:00.000Z",
+          "scheduledTime": "2026-08-14T11:46:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T12:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T12:00:00.000Z"
       }
     },
     {
@@ -666,15 +666,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-08-13T10:11:00.000Z",
+          "scheduledTime": "2026-08-14T10:11:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T10:15:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T10:15:00.000Z"
       }
     },
     {
@@ -694,15 +694,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-08-13T10:08:00.000Z",
+          "scheduledTime": "2026-08-14T10:08:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T10:15:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T10:15:00.000Z"
       }
     },
     {
@@ -718,9 +718,9 @@
       "nucleus": "Ventorrillo de Mayo",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T10:15:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T10:15:00.000Z"
       }
     },
     {
@@ -740,15 +740,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-08-13T10:05:00.000Z",
+          "scheduledTime": "2026-08-14T10:05:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T10:15:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T10:15:00.000Z"
       }
     },
     {
@@ -768,15 +768,15 @@
           "lineCode": "M-250",
           "lineName": "Málaga-Almogía",
           "destination": "Málaga",
-          "scheduledTime": "2026-08-13T10:02:00.000Z",
+          "scheduledTime": "2026-08-14T10:02:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T10:15:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T10:15:00.000Z"
       }
     },
     {
@@ -792,9 +792,9 @@
       "nucleus": "La Línea de la Concepción",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -814,7 +814,7 @@
           "lineCode": "M-161",
           "lineName": "Barbate-Facinas-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-08-13T10:10:00.000Z",
+          "scheduledTime": "2026-08-14T10:10:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -823,15 +823,15 @@
           "lineCode": "M-150",
           "lineName": "Algeciras-Tarifa",
           "destination": "Algeciras",
-          "scheduledTime": "2026-08-13T10:45:00.000Z",
+          "scheduledTime": "2026-08-14T10:45:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -851,7 +851,7 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-08-13T10:30:00.000Z",
+          "scheduledTime": "2026-08-14T10:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -860,15 +860,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Algeciras",
-          "scheduledTime": "2026-08-13T10:30:00.000Z",
+          "scheduledTime": "2026-08-14T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -888,15 +888,15 @@
           "lineCode": "M-110",
           "lineName": "Los Barrios-Algeciras Directo",
           "destination": "Los Barrios",
-          "scheduledTime": "2026-08-13T10:03:00.000Z",
+          "scheduledTime": "2026-08-14T10:03:00.000Z",
           "direction": 2,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -916,7 +916,7 @@
           "lineCode": "M-130",
           "lineName": "San Roque-Algeciras",
           "destination": "Algeciras",
-          "scheduledTime": "2026-08-13T10:45:00.000Z",
+          "scheduledTime": "2026-08-14T10:45:00.000Z",
           "direction": 1,
           "stopType": 1
         },
@@ -925,15 +925,15 @@
           "lineCode": "M-240",
           "lineName": "Estepona-La Línea (Ruta)",
           "destination": "Guadiaro",
-          "scheduledTime": "2026-08-13T11:00:00.000Z",
+          "scheduledTime": "2026-08-14T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -953,7 +953,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ADRA",
-          "scheduledTime": "2026-08-13T10:36:00.000Z",
+          "scheduledTime": "2026-08-14T10:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -962,7 +962,7 @@
           "lineCode": "M-380",
           "lineName": "Almería - Aguadulce - El Parador - Puebla de Vícar - El Ejido - Adra NN",
           "destination": "ALMERIA",
-          "scheduledTime": "2026-08-13T10:48:00.000Z",
+          "scheduledTime": "2026-08-14T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -971,15 +971,15 @@
           "lineCode": "M-384",
           "lineName": "El Ejido - Guardias Viejas - Balerma - Balanegra - Adra",
           "destination": "ADRA",
-          "scheduledTime": "2026-08-13T10:51:00.000Z",
+          "scheduledTime": "2026-08-14T10:51:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -995,9 +995,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -1013,9 +1013,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -1031,9 +1031,9 @@
       "nucleus": "ADRA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -1049,9 +1049,9 @@
       "nucleus": "LA ALCAZABA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T11:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T11:00:00.000Z"
       }
     },
     {
@@ -1067,9 +1067,9 @@
       "nucleus": "Los Villares",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T12:30:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T12:30:00.000Z"
       }
     },
     {
@@ -1089,7 +1089,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-08-13T10:20:00.000Z",
+          "scheduledTime": "2026-08-14T10:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1098,7 +1098,7 @@
           "lineCode": "M20-11",
           "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-13T10:38:00.000Z",
+          "scheduledTime": "2026-08-14T10:38:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1107,7 +1107,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-08-13T10:50:00.000Z",
+          "scheduledTime": "2026-08-14T10:50:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1116,7 +1116,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-13T11:13:00.000Z",
+          "scheduledTime": "2026-08-14T11:13:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1125,7 +1125,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-08-13T11:20:00.000Z",
+          "scheduledTime": "2026-08-14T11:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1134,7 +1134,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-13T11:43:00.000Z",
+          "scheduledTime": "2026-08-14T11:43:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1143,7 +1143,7 @@
           "lineCode": "M20-12",
           "lineName": "Jaén - Escañuela, 2024",
           "destination": "Escañuela",
-          "scheduledTime": "2026-08-13T11:55:00.000Z",
+          "scheduledTime": "2026-08-14T11:55:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1152,15 +1152,15 @@
           "lineCode": "M20-08",
           "lineName": "Jaén - Lopera, 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-08-13T12:20:00.000Z",
+          "scheduledTime": "2026-08-14T12:20:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T12:30:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T12:30:00.000Z"
       }
     },
     {
@@ -1180,7 +1180,7 @@
           "lineCode": "M20-11",
           "lineName": "Fuensanta de Martos - Jaén, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-13T10:25:00.000Z",
+          "scheduledTime": "2026-08-14T10:25:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1189,7 +1189,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-08-13T10:33:00.000Z",
+          "scheduledTime": "2026-08-14T10:33:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1198,7 +1198,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-13T11:00:00.000Z",
+          "scheduledTime": "2026-08-14T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1207,7 +1207,7 @@
           "lineCode": "M20-06",
           "lineName": "Jaén - Córdoba (Ruta), 2024",
           "destination": "Torredonjimeno",
-          "scheduledTime": "2026-08-13T11:03:00.000Z",
+          "scheduledTime": "2026-08-14T11:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1216,7 +1216,7 @@
           "lineCode": "M20-04",
           "lineName": "Jaén - Alcaudete, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-13T11:30:00.000Z",
+          "scheduledTime": "2026-08-14T11:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1225,7 +1225,7 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Martos",
-          "scheduledTime": "2026-08-13T11:33:00.000Z",
+          "scheduledTime": "2026-08-14T11:33:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1234,7 +1234,7 @@
           "lineCode": "M20-12",
           "lineName": "Jaén - Escañuela, 2024",
           "destination": "Escañuela",
-          "scheduledTime": "2026-08-13T12:08:00.000Z",
+          "scheduledTime": "2026-08-14T12:08:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1243,15 +1243,15 @@
           "lineCode": "M20-01",
           "lineName": "Jaén - Martos, 2024",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-13T12:25:00.000Z",
+          "scheduledTime": "2026-08-14T12:25:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T12:30:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T12:30:00.000Z"
       }
     },
     {
@@ -1271,7 +1271,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-13T10:00:00.000Z",
+          "scheduledTime": "2026-08-14T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1280,7 +1280,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-13T10:05:00.000Z",
+          "scheduledTime": "2026-08-14T10:05:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1289,7 +1289,7 @@
           "lineCode": "M16-3",
           "lineName": "Bailén - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-08-13T10:15:00.000Z",
+          "scheduledTime": "2026-08-14T10:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1298,7 +1298,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-08-13T10:40:00.000Z",
+          "scheduledTime": "2026-08-14T10:40:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1307,7 +1307,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-08-13T11:00:00.000Z",
+          "scheduledTime": "2026-08-14T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1316,7 +1316,7 @@
           "lineCode": "M16-1",
           "lineName": "Santa Elena - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-08-13T11:25:00.000Z",
+          "scheduledTime": "2026-08-14T11:25:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1325,7 +1325,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-13T11:30:00.000Z",
+          "scheduledTime": "2026-08-14T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1334,7 +1334,7 @@
           "lineCode": "M16-2",
           "lineName": "La Carolina - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-08-13T11:45:00.000Z",
+          "scheduledTime": "2026-08-14T11:45:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1343,7 +1343,7 @@
           "lineCode": "M04-8",
           "lineName": "Linares - Jaén",
           "destination": "Mengíbar",
-          "scheduledTime": "2026-08-13T11:55:00.000Z",
+          "scheduledTime": "2026-08-14T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1352,15 +1352,15 @@
           "lineCode": "M15-7",
           "lineName": "Jaén - Andújar - Marmolejo",
           "destination": "Andújar",
-          "scheduledTime": "2026-08-13T12:25:00.000Z",
+          "scheduledTime": "2026-08-14T12:25:00.000Z",
           "direction": 1,
           "stopType": 1
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T12:30:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T12:30:00.000Z"
       }
     },
     {
@@ -1380,7 +1380,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-13T10:30:00.000Z",
+          "scheduledTime": "2026-08-14T10:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1389,7 +1389,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-08-13T10:55:00.000Z",
+          "scheduledTime": "2026-08-14T10:55:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1398,7 +1398,7 @@
           "lineCode": "M3-103",
           "lineName": "Úbeda - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-08-13T11:00:00.000Z",
+          "scheduledTime": "2026-08-14T11:00:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1407,7 +1407,7 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Jaén",
-          "scheduledTime": "2026-08-13T11:30:00.000Z",
+          "scheduledTime": "2026-08-14T11:30:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1416,15 +1416,15 @@
           "lineCode": "M1-9",
           "lineName": "Mancha Real - Jaén",
           "destination": "Mancha Real",
-          "scheduledTime": "2026-08-13T11:55:00.000Z",
+          "scheduledTime": "2026-08-14T11:55:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T12:30:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T12:30:00.000Z"
       }
     },
     {
@@ -1440,9 +1440,9 @@
       "nucleus": "Villafranca De Córdoba",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-14T02:39:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-15T02:39:00.000Z"
       }
     },
     {
@@ -1458,9 +1458,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-14T02:39:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-15T02:39:00.000Z"
       }
     },
     {
@@ -1476,9 +1476,9 @@
       "nucleus": "Aldea Quintana",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-14T02:39:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-15T02:39:00.000Z"
       }
     },
     {
@@ -1494,9 +1494,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-14T02:39:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-15T02:39:00.000Z"
       }
     },
     {
@@ -1512,9 +1512,9 @@
       "nucleus": "Alcolea",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-14T02:39:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-15T02:39:00.000Z"
       }
     },
     {
@@ -1534,7 +1534,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-08-13T10:00:00.000Z",
+          "scheduledTime": "2026-08-14T10:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1543,7 +1543,7 @@
           "lineCode": "M-303",
           "lineName": "Huelva-Corrales-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-13T10:04:00.000Z",
+          "scheduledTime": "2026-08-14T10:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1552,7 +1552,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-13T10:21:00.000Z",
+          "scheduledTime": "2026-08-14T10:21:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1561,7 +1561,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-08-13T10:42:00.000Z",
+          "scheduledTime": "2026-08-14T10:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1570,7 +1570,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-08-13T11:00:00.000Z",
+          "scheduledTime": "2026-08-14T11:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1579,7 +1579,7 @@
           "lineCode": "M-303",
           "lineName": "Huelva-Corrales-Ayamonte",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-13T11:04:00.000Z",
+          "scheduledTime": "2026-08-14T11:04:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1588,7 +1588,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-13T11:11:00.000Z",
+          "scheduledTime": "2026-08-14T11:11:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1597,7 +1597,7 @@
           "lineCode": "M-902",
           "lineName": "Ayamonte-Huelva-Sevilla",
           "destination": "AYAMONTE",
-          "scheduledTime": "2026-08-13T11:21:00.000Z",
+          "scheduledTime": "2026-08-14T11:21:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1606,7 +1606,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-13T11:41:00.000Z",
+          "scheduledTime": "2026-08-14T11:41:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1615,7 +1615,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-08-13T11:42:00.000Z",
+          "scheduledTime": "2026-08-14T11:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1624,7 +1624,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-13T11:44:00.000Z",
+          "scheduledTime": "2026-08-14T11:44:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1633,7 +1633,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-08-13T12:00:00.000Z",
+          "scheduledTime": "2026-08-14T12:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1642,7 +1642,7 @@
           "lineCode": "M-316",
           "lineName": "Huelva-Ayamonte-San Silvestre De Guzman",
           "destination": "VILLABLANCA",
-          "scheduledTime": "2026-08-13T12:36:00.000Z",
+          "scheduledTime": "2026-08-14T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1651,7 +1651,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-08-13T12:42:00.000Z",
+          "scheduledTime": "2026-08-14T12:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1660,7 +1660,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LA ANTILLA",
-          "scheduledTime": "2026-08-13T13:00:00.000Z",
+          "scheduledTime": "2026-08-14T13:00:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1669,7 +1669,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-13T13:15:00.000Z",
+          "scheduledTime": "2026-08-14T13:15:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1678,7 +1678,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-13T13:21:00.000Z",
+          "scheduledTime": "2026-08-14T13:21:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1687,7 +1687,7 @@
           "lineCode": "M-313",
           "lineName": "Lepe-La Antilla",
           "destination": "LEPE",
-          "scheduledTime": "2026-08-13T13:42:00.000Z",
+          "scheduledTime": "2026-08-14T13:42:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1696,15 +1696,15 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-13T13:44:00.000Z",
+          "scheduledTime": "2026-08-14T13:44:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T14:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T14:00:00.000Z"
       }
     },
     {
@@ -1724,7 +1724,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-13T10:49:00.000Z",
+          "scheduledTime": "2026-08-14T10:49:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1733,7 +1733,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-13T11:20:00.000Z",
+          "scheduledTime": "2026-08-14T11:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1742,7 +1742,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-13T11:50:00.000Z",
+          "scheduledTime": "2026-08-14T11:50:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1751,7 +1751,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-13T12:20:00.000Z",
+          "scheduledTime": "2026-08-14T12:20:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1760,7 +1760,7 @@
           "lineCode": "M-309",
           "lineName": "Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-13T12:30:00.000Z",
+          "scheduledTime": "2026-08-14T12:30:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1769,7 +1769,7 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-13T13:20:00.000Z",
+          "scheduledTime": "2026-08-14T13:20:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1778,15 +1778,15 @@
           "lineCode": "M-905",
           "lineName": "Sevilla-Huelva-La Antilla-Isla Cristina",
           "destination": "ISLA CRISTINA",
-          "scheduledTime": "2026-08-13T13:49:00.000Z",
+          "scheduledTime": "2026-08-14T13:49:00.000Z",
           "direction": 1,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T14:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T14:00:00.000Z"
       }
     },
     {
@@ -1806,7 +1806,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-13T10:03:00.000Z",
+          "scheduledTime": "2026-08-14T10:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1815,7 +1815,7 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-13T10:14:00.000Z",
+          "scheduledTime": "2026-08-14T10:14:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1824,7 +1824,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-08-13T10:48:00.000Z",
+          "scheduledTime": "2026-08-14T10:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1833,7 +1833,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-13T11:03:00.000Z",
+          "scheduledTime": "2026-08-14T11:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1842,7 +1842,7 @@
           "lineCode": "M-417",
           "lineName": "Paterna-Torre Higuera",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-08-13T11:18:00.000Z",
+          "scheduledTime": "2026-08-14T11:18:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1851,7 +1851,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-08-13T11:48:00.000Z",
+          "scheduledTime": "2026-08-14T11:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1860,7 +1860,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-13T12:03:00.000Z",
+          "scheduledTime": "2026-08-14T12:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1869,7 +1869,7 @@
           "lineCode": "M-405",
           "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-08-13T12:36:00.000Z",
+          "scheduledTime": "2026-08-14T12:36:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1878,7 +1878,7 @@
           "lineCode": "M-906",
           "lineName": "Sevilla-Hinojos-Almonte-Bollullos-Rociana",
           "destination": "ROCIANA DEL CONDADO",
-          "scheduledTime": "2026-08-13T12:43:00.000Z",
+          "scheduledTime": "2026-08-14T12:43:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1887,7 +1887,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-08-13T12:48:00.000Z",
+          "scheduledTime": "2026-08-14T12:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1896,7 +1896,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "TORRE DE LA HIGUERA",
-          "scheduledTime": "2026-08-13T13:03:00.000Z",
+          "scheduledTime": "2026-08-14T13:03:00.000Z",
           "direction": 1,
           "stopType": 0
         },
@@ -1905,7 +1905,7 @@
           "lineCode": "M-417",
           "lineName": "Paterna-Torre Higuera",
           "destination": "BOLLULLOS PAR DEL CONDADO",
-          "scheduledTime": "2026-08-13T13:48:00.000Z",
+          "scheduledTime": "2026-08-14T13:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1914,7 +1914,7 @@
           "lineCode": "M-416",
           "lineName": "Almonte-Torre Higuera",
           "destination": "ALMONTE",
-          "scheduledTime": "2026-08-13T13:48:00.000Z",
+          "scheduledTime": "2026-08-14T13:48:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1923,7 +1923,7 @@
           "lineCode": "M-405",
           "lineName": "Huelva-Rociana-Almonte-Bollullos Par Del Condado",
           "destination": "HUELVA",
-          "scheduledTime": "2026-08-13T13:52:00.000Z",
+          "scheduledTime": "2026-08-14T13:52:00.000Z",
           "direction": 2,
           "stopType": 0
         },
@@ -1932,15 +1932,15 @@
           "lineCode": "M-911",
           "lineName": "Sevilla-Hinojos-Almonte-Caño Guerrero",
           "destination": "HINOJOS",
-          "scheduledTime": "2026-08-13T13:58:00.000Z",
+          "scheduledTime": "2026-08-14T13:58:00.000Z",
           "direction": 2,
           "stopType": 0
         }
       ],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T14:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T14:00:00.000Z"
       }
     },
     {
@@ -1956,9 +1956,9 @@
       "nucleus": "HUELVA",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T14:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T14:00:00.000Z"
       }
     },
     {
@@ -1974,9 +1974,9 @@
       "nucleus": "EL ROCIO",
       "services": [],
       "query": {
-        "requestedAt": "2026-08-13T06:17:43.573Z",
-        "startTime": "2026-08-13T10:00:00.000Z",
-        "endTime": "2026-08-13T14:00:00.000Z"
+        "requestedAt": "2026-08-14T06:15:04.054Z",
+        "startTime": "2026-08-14T10:00:00.000Z",
+        "endTime": "2026-08-14T14:00:00.000Z"
       }
     }
   ]

--- a/src/assets/data/stop-directory/chunks/consortium-1.json
+++ b/src/assets/data/stop-directory/chunks/consortium-1.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:35.678Z",
+    "generatedAt": "2026-08-14T06:14:55.106Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 1,

--- a/src/assets/data/stop-directory/chunks/consortium-2.json
+++ b/src/assets/data/stop-directory/chunks/consortium-2.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:35.678Z",
+    "generatedAt": "2026-08-14T06:14:55.106Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 2,

--- a/src/assets/data/stop-directory/chunks/consortium-3.json
+++ b/src/assets/data/stop-directory/chunks/consortium-3.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:35.678Z",
+    "generatedAt": "2026-08-14T06:14:55.106Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 3,

--- a/src/assets/data/stop-directory/chunks/consortium-4.json
+++ b/src/assets/data/stop-directory/chunks/consortium-4.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:35.678Z",
+    "generatedAt": "2026-08-14T06:14:55.106Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 4,

--- a/src/assets/data/stop-directory/chunks/consortium-5.json
+++ b/src/assets/data/stop-directory/chunks/consortium-5.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:35.678Z",
+    "generatedAt": "2026-08-14T06:14:55.106Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 5,

--- a/src/assets/data/stop-directory/chunks/consortium-6.json
+++ b/src/assets/data/stop-directory/chunks/consortium-6.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:35.678Z",
+    "generatedAt": "2026-08-14T06:14:55.106Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 6,

--- a/src/assets/data/stop-directory/chunks/consortium-7.json
+++ b/src/assets/data/stop-directory/chunks/consortium-7.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:35.678Z",
+    "generatedAt": "2026-08-14T06:14:55.106Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 7,

--- a/src/assets/data/stop-directory/chunks/consortium-8.json
+++ b/src/assets/data/stop-directory/chunks/consortium-8.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:35.678Z",
+    "generatedAt": "2026-08-14T06:14:55.106Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 8,

--- a/src/assets/data/stop-directory/chunks/consortium-9.json
+++ b/src/assets/data/stop-directory/chunks/consortium-9.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:35.678Z",
+    "generatedAt": "2026-08-14T06:14:55.106Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiumId": 9,

--- a/src/assets/data/stop-directory/index.json
+++ b/src/assets/data/stop-directory/index.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "generatedAt": "2026-08-13T06:17:35.678Z",
+    "generatedAt": "2026-08-14T06:14:55.106Z",
     "timezone": "Europe/Madrid",
     "providerName": "Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía",
     "consortiums": [


### PR DESCRIPTION
## Daily snapshot refresh

This pull request refreshes the transport data snapshots using the CTAN open data service.

<!-- resource-summary:start -->
- Data source: Portal de Datos Abiertos de la Red de Consorcios de Transporte de Andalucía (automatically fetched at 2026-08-14 06:15 UTC).
- Scripts: `npm run snapshot`, `npm run test:scripts`
<!-- resource-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Refreshed catalog and stop-directory metadata for August 14, 2026.
  * Regenerated the latest stop-service snapshot with updated schedule timestamps and overnight query windows.
  * Route, stop, municipality, direction, and service records remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->